### PR TITLE
fix: remove copyright section from footer localization files

### DIFF
--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -42,9 +42,5 @@
   "link.item.label.Privacy": {
     "message": "Privacy",
     "description": "The label of footer link with label=Privacy linking to /privacy"
-  },
-  "copyright": {
-    "message": "Copyright © 2024 OOMOL Contributors.",
-    "description": "The footer copyright"
   }
 }

--- a/i18n/zh-CN/docusaurus-theme-classic/footer.json
+++ b/i18n/zh-CN/docusaurus-theme-classic/footer.json
@@ -42,9 +42,5 @@
   "link.item.label.Privacy": {
     "message": "隐私政策",
     "description": "The label of footer link with label=Privacy linking to /privacy"
-  },
-  "copyright": {
-    "message": "Copyright © 2024 OOMOL Contributors.",
-    "description": "The footer copyright"
   }
 }


### PR DESCRIPTION
the copyright field already exists in file `docusaurus.config.js`