### PR TITLE
fix(pages): wrap DownloadButton, Navbar, and LocalDropdown with BrowserOnly to handle client-only logic

### DIFF
--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -4,6 +4,7 @@ import { Popover } from "../Popover";
 import { Button } from "../Button";
 import { translate } from "@docusaurus/Translate";
 import { downloadStable } from "@site/src/lib/utils";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 
 enum OS {
   Windows = "Windows",
@@ -55,54 +56,80 @@ export interface DownloadButtonProps {
 
 export const DownloadButton = ({ stableTag }: DownloadButtonProps) => {
   return (
-    <div className={styles["button-box"]}>
-      {detectOSAndArchitecture() === OS.MacOS ? (
-        <Popover
-          trigger={
-            <Button
-              className={styles.download}
-              icon={
-                <div
-                  className="i-codicon-desktop-download"
-                  style={{ fontSize: 18 }}
-                />
-              }
-            >
-              {translate({
-                message: stableTag
-                  ? "HOME.FirstScreen.download-macos-stable"
-                  : "HOME.FirstScreen.download-macos",
-              })}
-            </Button>
+    <BrowserOnly
+      fallback={
+        <Button
+          className={styles.download}
+          icon={
+            <div
+              className="i-codicon-desktop-download"
+              style={{ fontSize: 18 }}
+            />
           }
-          content={content}
-        />
-      ) : (
-        <div className={styles.windowsBox}>
-          <Button
-            className={styles.download}
-            onClick={() => downloadStable(null, DownloadUrl.Stable.Windows.x64)}
-            href={DownloadUrl.Stable.Windows.x64}
-            icon={
-              <div
-                className="i-codicon-desktop-download"
-                style={{ fontSize: 18 }}
+        >
+          {translate({
+            message: stableTag
+              ? "HOME.FirstScreen.download-macos-stable"
+              : "HOME.FirstScreen.download-macos",
+          })}
+        </Button>
+      }
+    >
+      {() => {
+        return (
+          <div className={styles["button-box"]}>
+            {detectOSAndArchitecture() === OS.MacOS ? (
+              <Popover
+                trigger={
+                  <Button
+                    className={styles.download}
+                    icon={
+                      <div
+                        className="i-codicon-desktop-download"
+                        style={{ fontSize: 18 }}
+                      />
+                    }
+                  >
+                    {translate({
+                      message: stableTag
+                        ? "HOME.FirstScreen.download-macos-stable"
+                        : "HOME.FirstScreen.download-macos",
+                    })}
+                  </Button>
+                }
+                content={content}
               />
-            }
-          >
-            {translate({
-              message: stableTag
-                ? "HOME.FirstScreen.download-windows-stable"
-                : "HOME.FirstScreen.download-windows",
-            })}
-          </Button>
-          <span className={styles.windowsSubtitle}>
-            {translate({
-              message: "HOME.FirstScreen.download-windows-subtitle",
-            })}
-          </span>
-        </div>
-      )}
-    </div>
+            ) : (
+              <div className={styles.windowsBox}>
+                <Button
+                  className={styles.download}
+                  onClick={() =>
+                    downloadStable(null, DownloadUrl.Stable.Windows.x64)
+                  }
+                  href={DownloadUrl.Stable.Windows.x64}
+                  icon={
+                    <div
+                      className="i-codicon-desktop-download"
+                      style={{ fontSize: 18 }}
+                    />
+                  }
+                >
+                  {translate({
+                    message: stableTag
+                      ? "HOME.FirstScreen.download-windows-stable"
+                      : "HOME.FirstScreen.download-windows",
+                  })}
+                </Button>
+                <span className={styles.windowsSubtitle}>
+                  {translate({
+                    message: "HOME.FirstScreen.download-windows-subtitle",
+                  })}
+                </span>
+              </div>
+            )}
+          </div>
+        );
+      }}
+    </BrowserOnly>
   );
 };

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -148,8 +148,11 @@ $desktop-width: 1280px;
 
 @media (min-width: 997px) {
   :root {
+    // TODO: 替换为新的 Navbar 样式后再恢复该样式
     // 已经手动调整 navbar 相关的样式，为了不让默认的影响新的样式，所以设为 0
-    --ifm-navbar-height: 0px;
+    // --ifm-navbar-height: 0px;
+
+    --ifm-navbar-height: 64px;
   }
 }
 

--- a/src/theme/Layout/index.tsx
+++ b/src/theme/Layout/index.tsx
@@ -1,12 +1,12 @@
 import "../../styles/uno.css";
 import styles from "./styles.module.scss";
 
-import React, { ReactNode, useEffect } from "react";
+import React, { ReactNode } from "react";
 import LayoutProvider from "@theme/Layout/Provider";
 import clsx from "clsx";
 import Navbar from "@theme/Navbar";
 import Footer from "@theme/Footer";
-import BrowserOnly from "@docusaurus/BrowserOnly";
+// import BrowserOnly from "@docusaurus/BrowserOnly";
 
 interface LayoutProps {
   children: ReactNode;
@@ -44,17 +44,11 @@ const Layout: React.FC<LayoutProps> = ({ children, wrapperClassName }) => {
   // }, []);
 
   return (
-    <BrowserOnly>
-      {() => (
-        <LayoutProvider>
-          <Navbar />
-          <div className={clsx(styles.wrapper, wrapperClassName)}>
-            {children}
-          </div>
-          <Footer />
-        </LayoutProvider>
-      )}
-    </BrowserOnly>
+    <LayoutProvider>
+      <Navbar />
+      <div className={clsx(styles.wrapper, wrapperClassName)}>{children}</div>
+      <Footer />
+    </LayoutProvider>
   );
 };
 

--- a/src/theme/Layout/index.tsx
+++ b/src/theme/Layout/index.tsx
@@ -6,7 +6,6 @@ import LayoutProvider from "@theme/Layout/Provider";
 import clsx from "clsx";
 import Navbar from "@theme/Navbar";
 import Footer from "@theme/Footer";
-// import BrowserOnly from "@docusaurus/BrowserOnly";
 
 interface LayoutProps {
   children: ReactNode;

--- a/src/theme/Navbar/index.tsx
+++ b/src/theme/Navbar/index.tsx
@@ -11,6 +11,7 @@ import Link from "@docusaurus/Link";
 import { useNavbarMobileSidebar } from "@docusaurus/theme-common/internal";
 import NavbarMobileSidebar from "@theme/Navbar/MobileSidebar";
 import { translate } from "@docusaurus/Translate";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 
 const isSignedIn = () => {
   const cookies = document.cookie.split(";").map(cookie => cookie.trim());
@@ -140,15 +141,28 @@ const Navbar: React.FC<NavbarProps> = memo(() => {
           {leftItems.map((item, i) => (
             <NavbarItem {...item} key={i} />
           ))}
-          <NavbarItem
-            style={{ cursor: "pointer" }}
-            label={
-              isSignedIn()
-                ? translate({ message: "Theme.Navbar.go-to-hub-flow" })
-                : translate({ message: "Theme.Navbar.sign-in" })
+          <BrowserOnly
+            // TODO: This is a temporary fallback element used to prevent layout issues.
+            fallback={
+              <NavbarItem
+                label={translate({ message: "Theme.Navbar.sign-in" })}
+              />
             }
-            onClick={handleSignin}
-          />
+          >
+            {() => {
+              return (
+                <NavbarItem
+                  style={{ cursor: "pointer" }}
+                  label={
+                    isSignedIn()
+                      ? translate({ message: "Theme.Navbar.go-to-hub-flow" })
+                      : translate({ message: "Theme.Navbar.sign-in" })
+                  }
+                  onClick={handleSignin}
+                />
+              );
+            }}
+          </BrowserOnly>
         </div>
         <div className={styles.itemsRight}>
           {rightItems.map((item, i) => (

--- a/src/theme/components/LocalDropdown.tsx
+++ b/src/theme/components/LocalDropdown.tsx
@@ -5,6 +5,7 @@ import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import { useAlternatePageUtils } from "@docusaurus/theme-common/internal";
 import { Button } from "@site/src/components/Button";
 import { useState } from "react";
+import BrowserOnly from "@docusaurus/BrowserOnly";
 
 export interface LocalDropdownProps {
   queryString?: string;
@@ -47,14 +48,18 @@ export const LocalDropdown = ({ queryString = "" }: LocalDropdownProps) => {
           // preserve ?search#hash suffix on locale switches
           const to = `${baseTo}${search}${hash}${queryString}`;
           return (
-            <a
-              key={locale}
-              href={to}
-              className={`${styles.item} ${locale === currentLocale ? styles.selected : ""}`}
-              onClick={() => handleLocaleChange(locale)}
-            >
-              <div>{formateLocale(locale)}</div>
-            </a>
+            <BrowserOnly>
+              {() => (
+                <a
+                  key={locale}
+                  href={to}
+                  className={`${styles.item} ${locale === currentLocale ? styles.selected : ""}`}
+                  onClick={() => handleLocaleChange(locale)}
+                >
+                  <div>{formateLocale(locale)}</div>
+                </a>
+              )}
+            </BrowserOnly>
           );
         })}
       </div>

--- a/src/theme/components/LocalDropdown.tsx
+++ b/src/theme/components/LocalDropdown.tsx
@@ -48,10 +48,9 @@ export const LocalDropdown = ({ queryString = "" }: LocalDropdownProps) => {
           // preserve ?search#hash suffix on locale switches
           const to = `${baseTo}${search}${hash}${queryString}`;
           return (
-            <BrowserOnly>
+            <BrowserOnly key={locale}>
               {() => (
                 <a
-                  key={locale}
                   href={to}
                   className={`${styles.item} ${locale === currentLocale ? styles.selected : ""}`}
                   onClick={() => handleLocaleChange(locale)}


### PR DESCRIPTION
- fix(theme): remove BrowserOnly from Layout since wrapping the entire layout prevented static HTML generation for docs