### PR TITLE
chore: add .well-known

### DIFF
--- a/static/.well-known/microsoft-identity-association.json
+++ b/static/.well-known/microsoft-identity-association.json
@@ -1,0 +1,7 @@
+{
+  "associatedApplications": [
+    {
+      "applicationId": "da12b9b4-74de-4fe3-a28d-8503e9dab6ba"
+    }
+  ]
+}


### PR DESCRIPTION
微软 OAuth2 需要验证网域，同时，`.well-known` 目录在未来也会需要(iOS 跳转等)

<img width="5014" height="1336" alt="CleanShot 2025-08-29 at 10 32 24" src="https://github.com/user-attachments/assets/3ca47a98-9661-462f-b3bf-201bd4c9a69e" />