### PR TITLE
[codex] fix navbar i18n labels

### DIFF
--- a/i18n/en/docusaurus-theme-classic/navbar.json
+++ b/i18n/en/docusaurus-theme-classic/navbar.json
@@ -43,6 +43,10 @@
     "message": "Use",
     "description": "Navbar item with label navbar.use"
   },
+  "item.label.navbar.oo-cli": {
+    "message": "oo-cli",
+    "description": "Navbar item with label navbar.oo-cli"
+  },
   "item.label.navbar.oomol-studio": {
     "message": "OOMOL Studio",
     "description": "Navbar item with label navbar.oomol-studio"
@@ -58,6 +62,10 @@
   "item.label.navbar.oomol-cloud": {
     "message": "OOMOL Cloud",
     "description": "Navbar item with label navbar.oomol-cloud"
+  },
+  "item.label.navbar.oomol-ai": {
+    "message": "OOMOL AI",
+    "description": "Navbar item with label navbar.oomol-ai"
   },
   "item.label.navbar.oomol-sdk": {
     "message": "OOMOL SDK",

--- a/i18n/zh-CN/docusaurus-theme-classic/navbar.json
+++ b/i18n/zh-CN/docusaurus-theme-classic/navbar.json
@@ -43,6 +43,10 @@
     "message": "使用",
     "description": "Navbar item with label navbar.use"
   },
+  "item.label.navbar.oo-cli": {
+    "message": "oo-cli",
+    "description": "Navbar item with label navbar.oo-cli"
+  },
   "item.label.navbar.oomol-studio": {
     "message": "OOMOL Studio",
     "description": "Navbar item with label navbar.oomol-studio"
@@ -58,6 +62,10 @@
   "item.label.navbar.oomol-cloud": {
     "message": "OOMOL Cloud",
     "description": "Navbar item with label navbar.oomol-cloud"
+  },
+  "item.label.navbar.oomol-ai": {
+    "message": "OOMOL AI",
+    "description": "Navbar item with label navbar.oomol-ai"
   },
   "item.label.navbar.oomol-sdk": {
     "message": "OOMOL SDK",


### PR DESCRIPTION
## Summary
This PR fixes missing navbar i18n labels in the mobile sidebar.

## What changed
- added `item.label.navbar.oo-cli` to the English navbar translations
- added `item.label.navbar.oo-cli` to the Simplified Chinese navbar translations
- added `item.label.navbar.oomol-ai` to the English navbar translations
- added `item.label.navbar.oomol-ai` to the Simplified Chinese navbar translations

## Root cause
The custom navbar UI translated these product labels on desktop, but the mobile sidebar relied on Docusaurus navbar translation resources. The required navbar translation keys were missing, so the raw label keys like `navbar.oo-cli` and `navbar.oomol-ai` were rendered directly.

## Impact
Mobile navigation now shows the expected localized product names instead of raw translation keys.

## Validation
- parsed both updated navbar translation JSON files successfully with Node.js