### PR TITLE
[codex] Fix dark mode surface styling

### DIFF
--- a/src/components/CookieConsent/styles.module.scss
+++ b/src/components/CookieConsent/styles.module.scss
@@ -6,7 +6,7 @@
   width: min(28rem, calc(100vw - 24px * 2));
   border: 1px solid var(--oomol-border-subtle);
   border-radius: 18px;
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 94%, white 6%);
+  background: var(--oomol-surface-float);
   box-shadow: var(--oomol-shadow-lg);
   backdrop-filter: blur(16px) saturate(130%);
   color: var(--oomol-text-secondary);
@@ -63,19 +63,11 @@
   button.manageCancelButton {
     color: var(--oomol-text-primary);
     border-color: var(--oomol-border-default);
-    background-color: color-mix(
-      in srgb,
-      var(--oomol-bg-container) 88%,
-      white 12%
-    );
+    background-color: var(--oomol-surface-panel);
 
     &:hover {
       border-color: var(--oomol-border-strong);
-      background-color: color-mix(
-        in srgb,
-        var(--oomol-bg-spotlight) 82%,
-        white 18%
-      );
+      background-color: var(--oomol-surface-panel-strong);
     }
   }
 }

--- a/src/components/HomepageCliEntry/styles.module.scss
+++ b/src/components/HomepageCliEntry/styles.module.scss
@@ -78,15 +78,14 @@
   display: grid;
   gap: 0.42rem;
   padding: 0.95rem 1rem 1rem;
-  border: 1px solid color-mix(in srgb, var(--oomol-border-default) 82%, white);
+  border: 1px solid
+    color-mix(in srgb, var(--oomol-border-default) 82%, transparent);
   border-radius: 1.1rem;
-  background:
-    linear-gradient(
-      180deg,
-      rgba(255, 255, 255, 0.72),
-      rgba(255, 255, 255, 0.4)
-    ),
-    color-mix(in srgb, var(--oomol-bg-elevated) 88%, white 12%);
+  background: linear-gradient(
+    180deg,
+    var(--oomol-surface-float) 0%,
+    var(--oomol-surface-panel) 100%
+  );
   box-shadow: 0 14px 26px rgba(130, 142, 181, 0.08);
 }
 
@@ -97,7 +96,11 @@
   min-height: 1.7rem;
   padding: 0 0.62rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--oomol-primary-bg) 60%, white);
+  background: color-mix(
+    in srgb,
+    var(--oomol-primary-bg) 60%,
+    var(--oomol-bg-elevated) 40%
+  );
   color: var(--oomol-primary-text);
   font-size: 0.76rem;
   font-weight: 700;
@@ -125,7 +128,7 @@
   padding: 1rem 1.05rem;
   border: 1px solid var(--oomol-divider);
   border-radius: 1.25rem;
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 90%, white 10%);
+  background: var(--oomol-surface-float);
 }
 
 .stepIndex {
@@ -221,7 +224,7 @@
 
 .secondaryAction {
   color: var(--oomol-text-primary);
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 88%, white 12%);
+  background: var(--oomol-surface-float);
   border: 1px solid var(--oomol-divider);
 }
 

--- a/src/components/HomepageCodexBlocks/styles.module.scss
+++ b/src/components/HomepageCodexBlocks/styles.module.scss
@@ -359,3 +359,67 @@
     line-height: 1.58;
   }
 }
+
+[data-theme="dark"] {
+  .section {
+    background:
+      radial-gradient(
+        circle at 85% 20%,
+        rgba(124, 132, 225, 0.1) 0%,
+        rgba(124, 132, 225, 0) 28%
+      ),
+      linear-gradient(
+        180deg,
+        color-mix(
+            in srgb,
+            var(--oomol-bg-base) 90%,
+            var(--oomol-bg-container) 10%
+          )
+          0%,
+        color-mix(in srgb, var(--oomol-bg-base) 96%, black 4%) 100%
+      );
+    box-shadow:
+      inset 0 1px 0 var(--oomol-divider-subtle),
+      inset 0 -1px 0 var(--oomol-divider-subtle);
+  }
+
+  .secondaryAction,
+  .card {
+    border-color: color-mix(
+      in srgb,
+      var(--oomol-border-default) 72%,
+      var(--oomol-divider)
+    );
+    background: linear-gradient(
+      180deg,
+      color-mix(
+          in srgb,
+          var(--oomol-bg-elevated) 82%,
+          var(--oomol-bg-container) 18%
+        )
+        0%,
+      color-mix(in srgb, var(--oomol-bg-container) 88%, black 12%) 100%
+    );
+  }
+
+  .iconWrap {
+    border-color: color-mix(
+      in srgb,
+      var(--oomol-border-default) 68%,
+      var(--oomol-divider)
+    );
+    background: color-mix(
+      in srgb,
+      var(--oomol-bg-container) 82%,
+      var(--oomol-bg-elevated) 18%
+    );
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.04),
+      0 10px 20px rgba(0, 0, 0, 0.14);
+  }
+
+  .videoMetaTitle,
+  .videoMetaNote {
+    color: color-mix(in srgb, var(--oomol-text-secondary) 92%, white 8%);
+  }
+}

--- a/src/components/HomepageDeveloperBenefits/styles.module.scss
+++ b/src/components/HomepageDeveloperBenefits/styles.module.scss
@@ -89,7 +89,7 @@
   padding: 1.35rem 1.4rem 1.45rem;
   border: 1px solid var(--oomol-divider);
   border-radius: 1.7rem;
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 92%, white 8%);
+  background: var(--oomol-surface-float);
   box-shadow: var(--oomol-shadow-sm);
   position: relative;
   overflow: hidden;
@@ -137,7 +137,7 @@
   padding: 0.32rem 0.7rem;
   border-radius: 999px;
   border: 1px solid var(--oomol-divider);
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 82%, white 18%);
+  background: var(--oomol-surface-panel);
 }
 
 .valueBox {
@@ -202,7 +202,11 @@
   min-height: 2.5rem;
   padding: 0 0.85rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--oomol-primary-bg) 70%, white 30%);
+  background: color-mix(
+    in srgb,
+    var(--oomol-primary-bg) 70%,
+    var(--oomol-bg-elevated) 30%
+  );
   font-size: 0.96rem;
   font-weight: 650;
   color: var(--oomol-primary-text);
@@ -218,7 +222,7 @@
     background: color-mix(
       in srgb,
       var(--oomol-primary-bg-hover) 76%,
-      white 24%
+      var(--oomol-bg-elevated) 24%
     );
 
     &::after {

--- a/src/components/HomepageFirstScreen/styles.module.scss
+++ b/src/components/HomepageFirstScreen/styles.module.scss
@@ -409,6 +409,29 @@
     color: color-mix(in srgb, var(--oomol-primary-text) 86%, white 14%);
   }
 
+  .secondaryCta {
+    border-color: color-mix(
+      in srgb,
+      var(--oomol-border-default) 72%,
+      var(--oomol-divider)
+    );
+    background: color-mix(
+      in srgb,
+      var(--oomol-bg-elevated) 80%,
+      var(--oomol-bg-container) 20%
+    );
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.18);
+
+    &:hover {
+      border-color: color-mix(
+        in srgb,
+        var(--oomol-primary) 24%,
+        var(--oomol-divider)
+      );
+      box-shadow: 0 18px 32px rgba(0, 0, 0, 0.22);
+    }
+  }
+
   .videoShowcase {
     background: transparent;
   }

--- a/src/components/HomepageLinearFlow/styles.module.scss
+++ b/src/components/HomepageLinearFlow/styles.module.scss
@@ -645,6 +645,11 @@
   .terminalPanel,
   .mediaPanel,
   .agentMediaCard {
+    border-color: color-mix(
+      in srgb,
+      var(--oomol-border-default) 72%,
+      var(--oomol-divider)
+    );
     background: color-mix(
       in srgb,
       var(--oomol-bg-elevated) 86%,
@@ -653,6 +658,11 @@
   }
 
   .videoCardMeta {
+    border-top-color: color-mix(
+      in srgb,
+      var(--oomol-border-default) 68%,
+      var(--oomol-divider)
+    );
     background: color-mix(
       in srgb,
       var(--oomol-bg-elevated) 86%,
@@ -724,6 +734,19 @@
     color: color-mix(in srgb, var(--oomol-text-secondary) 92%, white 8%);
   }
 
+  .cloudMetaPill {
+    border-color: color-mix(
+      in srgb,
+      var(--oomol-border-default) 72%,
+      var(--oomol-divider)
+    );
+    background: color-mix(
+      in srgb,
+      var(--oomol-bg-elevated) 82%,
+      var(--oomol-bg-container) 18%
+    );
+  }
+
   .placeholderCard {
     background:
       linear-gradient(rgba(188, 194, 224, 0.07) 1px, transparent 1px),
@@ -754,10 +777,10 @@
       linear-gradient(
         180deg,
         color-mix(
-            in srgb,
-            var(--oomol-bg-container) 82%,
-            var(--oomol-bg-spotlight) 18%
-          )
+          in srgb,
+          var(--oomol-bg-container) 82%,
+          var(--oomol-bg-spotlight) 18%
+        )
           0%,
         color-mix(in srgb, var(--oomol-bg-elevated) 88%, black 12%) 100%
       );

--- a/src/components/HomepagePainPoints/styles.module.scss
+++ b/src/components/HomepagePainPoints/styles.module.scss
@@ -63,7 +63,7 @@
   padding: 1.6rem 1.5rem 1.8rem;
   border: 1px solid var(--oomol-divider);
   border-radius: 1.7rem;
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 92%, white 8%);
+  background: var(--oomol-surface-float);
   box-shadow: var(--oomol-shadow-sm);
   position: relative;
   overflow: hidden;

--- a/src/components/HomepageProductComparison/styles.module.scss
+++ b/src/components/HomepageProductComparison/styles.module.scss
@@ -250,7 +250,7 @@
   padding: 1.2rem;
   border-radius: 1.8rem;
   border: 1px solid var(--oomol-divider);
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 94%, white 6%);
+  background: var(--oomol-surface-float);
   box-shadow: var(--oomol-shadow-md);
   min-height: 100%;
   transition:
@@ -265,7 +265,7 @@
 .outputCard {
   border-radius: 1.2rem;
   border: 1px solid var(--oomol-divider);
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 92%, white 8%);
+  background: var(--oomol-surface-panel);
 }
 
 .outputsIntro {

--- a/src/components/HomepageProofLayer/styles.module.scss
+++ b/src/components/HomepageProofLayer/styles.module.scss
@@ -72,7 +72,7 @@
   padding: 1.1rem 1.15rem 1.2rem;
   border: 1px solid var(--oomol-divider);
   border-radius: 1.35rem;
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 92%, white 8%);
+  background: var(--oomol-surface-float);
   box-shadow: var(--oomol-shadow-sm);
 }
 
@@ -119,7 +119,7 @@
   padding: 1rem;
   border-radius: 1.5rem;
   border: 1px solid var(--oomol-divider);
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 90%, white 10%);
+  background: var(--oomol-surface-float);
   box-shadow: var(--oomol-shadow-sm);
   transition:
     transform 0.2s ease,
@@ -139,7 +139,11 @@
       rgba(132, 138, 208, 0.08) 0%,
       rgba(132, 138, 208, 0) 38%
     ),
-    color-mix(in srgb, var(--oomol-bg-elevated) 92%, white 8%);
+    color-mix(
+      in srgb,
+      var(--oomol-primary-bg) 34%,
+      var(--oomol-surface-float) 66%
+    );
 
   .caseTitle {
     font-size: 1.75rem;
@@ -165,7 +169,7 @@
   object-position: top center;
   border-radius: 1rem;
   border: 1px solid color-mix(in srgb, var(--oomol-divider) 86%, white 14%);
-  background: var(--oomol-white);
+  background: var(--oomol-bg-elevated);
   box-shadow: var(--oomol-shadow-md);
 }
 

--- a/src/components/Popover/styles.module.scss
+++ b/src/components/Popover/styles.module.scss
@@ -7,7 +7,7 @@
     border-radius: 18px;
     border: 1px solid
       color-mix(in srgb, var(--oomol-border-default) 72%, transparent);
-    background: color-mix(in srgb, var(--oomol-bg-elevated) 96%, white);
+    background: var(--oomol-surface-float);
     box-shadow: var(--oomol-shadow-md);
   }
 

--- a/src/components/ui/button.module.scss
+++ b/src/components/ui/button.module.scss
@@ -43,7 +43,7 @@
 
 .variantOutline {
   &:global(.arco-btn-outline) {
-    background: color-mix(in srgb, var(--oomol-bg-elevated) 90%, white);
+    background: var(--oomol-surface-float);
     border-color: var(--oomol-border-default);
     color: var(--oomol-text-primary);
   }

--- a/src/components/ui/card.module.scss
+++ b/src/components/ui/card.module.scss
@@ -6,7 +6,7 @@
     var(--oomol-border-default) 72%,
     transparent
   ) !important;
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 94%, white);
+  background: var(--oomol-surface-float);
   box-shadow: var(--oomol-shadow-sm);
 
   :global(.arco-card-body) {

--- a/src/pages/cloud/styles.module.scss
+++ b/src/pages/cloud/styles.module.scss
@@ -4,8 +4,8 @@
   background:
     radial-gradient(
       circle at top left,
-      rgba(155, 174, 226, 0.12) 0%,
-      rgba(155, 174, 226, 0) 34%
+      color-mix(in srgb, var(--oomol-primary) 16%, transparent) 0%,
+      transparent 34%
     ),
     linear-gradient(
       180deg,
@@ -368,6 +368,25 @@
 }
 
 [data-theme="dark"] {
+  .page {
+    background:
+      radial-gradient(
+        circle at top left,
+        color-mix(in srgb, var(--oomol-primary) 14%, transparent) 0%,
+        transparent 36%
+      ),
+      linear-gradient(
+        180deg,
+        color-mix(
+            in srgb,
+            var(--oomol-bg-base) 90%,
+            var(--oomol-bg-container) 10%
+          )
+          0%,
+        color-mix(in srgb, var(--oomol-bg-base) 96%, black 4%) 100%
+      );
+  }
+
   .heroNote {
     border-color: color-mix(
       in srgb,
@@ -380,5 +399,35 @@
       var(--oomol-primary-bg) 22%
     );
     color: color-mix(in srgb, var(--oomol-text-secondary) 92%, white 8%);
+  }
+
+  .stat,
+  .secondaryAction,
+  .visualFrame,
+  .modeCard,
+  .projectCard,
+  .pricingCard {
+    border-color: color-mix(
+      in srgb,
+      var(--oomol-border-default) 72%,
+      var(--oomol-divider)
+    );
+    background: linear-gradient(
+      180deg,
+      color-mix(
+          in srgb,
+          var(--oomol-bg-elevated) 82%,
+          var(--oomol-bg-container) 18%
+        )
+        0%,
+      color-mix(in srgb, var(--oomol-bg-container) 88%, black 12%) 100%
+    );
+  }
+
+  .visualFrame,
+  .modeCard,
+  .projectCard,
+  .pricingCard {
+    box-shadow: none;
   }
 }

--- a/src/pages/pricing/styles.module.scss
+++ b/src/pages/pricing/styles.module.scss
@@ -78,8 +78,13 @@
       color-mix(in srgb, var(--oomol-primary) 16%, var(--oomol-border-default));
     background: linear-gradient(
       135deg,
-      color-mix(in srgb, var(--oomol-primary-bg) 74%, white 26%) 0%,
-      color-mix(in srgb, var(--oomol-bg-elevated) 92%, white 8%) 100%
+      color-mix(
+          in srgb,
+          var(--oomol-primary-bg) 64%,
+          var(--oomol-bg-elevated) 36%
+        )
+        0%,
+      var(--oomol-surface-float) 100%
     );
     box-shadow: none;
   }
@@ -107,10 +112,11 @@
   border-radius: 22px;
   background: linear-gradient(
     180deg,
-    color-mix(in srgb, var(--oomol-bg-elevated) 94%, white 6%) 0%,
-    color-mix(in srgb, var(--oomol-bg-base) 92%, white 8%) 100%
+    var(--oomol-surface-float) 0%,
+    var(--oomol-surface-panel) 100%
   );
-  border: 1px solid color-mix(in srgb, var(--oomol-border-default) 86%, white);
+  border: 1px solid
+    color-mix(in srgb, var(--oomol-border-default) 84%, transparent);
   box-shadow: var(--oomol-shadow-sm);
 }
 
@@ -120,7 +126,11 @@
   width: fit-content;
   padding: 6px 12px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--oomol-primary-bg) 58%, white 42%);
+  background: color-mix(
+    in srgb,
+    var(--oomol-primary-bg) 58%,
+    var(--oomol-bg-elevated) 42%
+  );
   color: var(--oomol-primary);
   font-size: 12px;
   line-height: 16px;
@@ -700,7 +710,7 @@
   padding: clamp(28px, 4vw, 46px);
   border-radius: 36px;
   border: 1px solid
-    color-mix(in srgb, var(--oomol-border-default) 78%, white 22%);
+    color-mix(in srgb, var(--oomol-border-default) 78%, transparent);
   background:
     radial-gradient(
       circle at top right,
@@ -709,8 +719,8 @@
     ),
     linear-gradient(
       180deg,
-      color-mix(in srgb, var(--oomol-bg-elevated) 95%, white 5%) 0%,
-      color-mix(in srgb, var(--oomol-bg-base) 96%, white 4%) 100%
+      var(--oomol-surface-float) 0%,
+      var(--oomol-surface-panel) 100%
     );
   box-shadow:
     0 24px 60px rgba(31, 41, 59, 0.06),
@@ -763,8 +773,13 @@
     color-mix(in srgb, var(--oomol-primary) 16%, var(--oomol-border-default));
   background: linear-gradient(
     180deg,
-    color-mix(in srgb, var(--oomol-primary-bg) 44%, white 56%) 0%,
-    color-mix(in srgb, var(--oomol-bg-elevated) 94%, white 6%) 100%
+    color-mix(
+        in srgb,
+        var(--oomol-primary-bg) 44%,
+        var(--oomol-bg-elevated) 56%
+      )
+      0%,
+    var(--oomol-surface-float) 100%
   );
   color: var(--oomol-text-secondary);
   font-size: 13px;
@@ -776,7 +791,11 @@
     width: 8px;
     height: 8px;
     border-radius: 999px;
-    background: color-mix(in srgb, var(--oomol-primary) 74%, white);
+    background: color-mix(
+      in srgb,
+      var(--oomol-primary) 74%,
+      var(--oomol-bg-elevated) 26%
+    );
     box-shadow: 0 0 0 6px
       color-mix(in srgb, var(--oomol-primary-bg) 44%, transparent);
   }
@@ -850,8 +869,13 @@
     border: 1px solid color-mix(in srgb, var(--oomol-primary) 10%, transparent);
     background: linear-gradient(
       90deg,
-      color-mix(in srgb, var(--oomol-primary-bg) 54%, white 46%) 0%,
-      color-mix(in srgb, var(--oomol-bg-elevated) 98%, white 2%) 100%
+      color-mix(
+          in srgb,
+          var(--oomol-primary-bg) 54%,
+          var(--oomol-bg-elevated) 46%
+        )
+        0%,
+      var(--oomol-surface-float) 100%
     );
     box-shadow: none;
   }
@@ -872,8 +896,8 @@
   border-radius: 26px;
   background: linear-gradient(
     180deg,
-    color-mix(in srgb, var(--oomol-bg-base) 94%, white 6%) 0%,
-    color-mix(in srgb, var(--oomol-bg-elevated) 96%, white 4%) 100%
+    var(--oomol-surface-panel) 0%,
+    var(--oomol-surface-float) 100%
   );
   color: var(--oomol-text-secondary);
   font-size: 16px;
@@ -899,7 +923,7 @@
   }
 
   :global(.arco-table-header) {
-    background: color-mix(in srgb, var(--oomol-bg-elevated) 94%, white 6%);
+    background: var(--oomol-surface-float);
   }
 
   :global(.arco-table-th) {
@@ -940,7 +964,11 @@
   max-width: 100%;
   padding: 7px 14px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--oomol-primary-bg) 62%, white 38%);
+  background: color-mix(
+    in srgb,
+    var(--oomol-primary-bg) 56%,
+    var(--oomol-bg-elevated) 44%
+  );
   border: 1px solid
     color-mix(in srgb, var(--oomol-primary) 14%, var(--oomol-border-default));
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.64);

--- a/src/pages/studio/styles.module.scss
+++ b/src/pages/studio/styles.module.scss
@@ -4,13 +4,13 @@
   background:
     radial-gradient(
       circle at top left,
-      rgba(161, 191, 235, 0.14) 0%,
-      rgba(161, 191, 235, 0) 36%
+      color-mix(in srgb, var(--oomol-primary) 18%, transparent) 0%,
+      transparent 36%
     ),
     linear-gradient(
       180deg,
-      rgba(251, 253, 255, 0.96) 0%,
-      rgba(244, 247, 251, 0.92) 100%
+      color-mix(in srgb, var(--oomol-bg-layout) 92%, white 8%) 0%,
+      var(--oomol-bg-base) 100%
     );
 }
 
@@ -362,5 +362,86 @@
   .ctaTitle {
     max-width: 100%;
     text-wrap: pretty;
+  }
+}
+
+[data-theme="dark"] {
+  .page {
+    background:
+      radial-gradient(
+        circle at top left,
+        color-mix(in srgb, var(--oomol-primary) 16%, transparent) 0%,
+        transparent 38%
+      ),
+      linear-gradient(
+        180deg,
+        color-mix(
+            in srgb,
+            var(--oomol-bg-base) 90%,
+            var(--oomol-bg-container) 10%
+          )
+          0%,
+        color-mix(in srgb, var(--oomol-bg-base) 96%, black 4%) 100%
+      );
+  }
+
+  .secondaryAction {
+    border-color: color-mix(
+      in srgb,
+      var(--oomol-border-default) 72%,
+      var(--oomol-divider)
+    );
+    background: color-mix(
+      in srgb,
+      var(--oomol-bg-elevated) 80%,
+      var(--oomol-bg-container) 20%
+    );
+  }
+
+  .quoteCard {
+    border-color: color-mix(
+      in srgb,
+      var(--oomol-primary-border) 72%,
+      var(--oomol-divider)
+    );
+    background: linear-gradient(
+      180deg,
+      color-mix(
+          in srgb,
+          var(--oomol-primary-bg) 58%,
+          var(--oomol-bg-elevated) 42%
+        )
+        0%,
+      color-mix(
+          in srgb,
+          var(--oomol-primary-bg) 34%,
+          var(--oomol-bg-container) 66%
+        )
+        100%
+    );
+  }
+
+  .visualFrame,
+  .principleMedia {
+    border-color: color-mix(
+      in srgb,
+      var(--oomol-border-default) 72%,
+      var(--oomol-divider)
+    );
+    background: linear-gradient(
+      180deg,
+      color-mix(
+          in srgb,
+          var(--oomol-bg-elevated) 82%,
+          var(--oomol-bg-container) 18%
+        )
+        0%,
+      color-mix(in srgb, var(--oomol-bg-container) 88%, black 12%) 100%
+    );
+    box-shadow: none;
+  }
+
+  .principleCard {
+    border-top-color: color-mix(in srgb, var(--oomol-divider) 84%, white 16%);
   }
 }

--- a/src/pages/support/styles.module.scss
+++ b/src/pages/support/styles.module.scss
@@ -6,6 +6,7 @@
   flex-direction: column;
   margin-top: 64px;
   margin-bottom: 240px;
+  color: var(--oomol-text-primary);
 }
 
 .supportTitle {
@@ -15,6 +16,7 @@
   text-align: center;
   margin-top: 64px;
   margin-bottom: 120px;
+  color: var(--oomol-text-primary);
 }
 
 .supportCellBox {
@@ -33,7 +35,7 @@
   border-style: solid;
   border-color: var(--oomol-border-default);
   border-radius: 18px;
-  background: color-mix(in srgb, var(--oomol-bg-elevated) 94%, white);
+  background: var(--oomol-surface-float);
 }
 
 .supportHeader {
@@ -46,6 +48,7 @@
   font-size: 18px;
   display: flex;
   align-items: center;
+  color: var(--oomol-text-primary);
 }
 
 .support-title {
@@ -61,4 +64,19 @@
   margin-bottom: 42px;
   font-size: 14px;
   color: var(--oomol-text-secondary);
+}
+
+[data-theme="dark"] {
+  .supportCell {
+    border-color: color-mix(
+      in srgb,
+      var(--oomol-border-default) 72%,
+      var(--oomol-divider)
+    );
+    background: linear-gradient(
+      180deg,
+      var(--oomol-surface-float) 0%,
+      var(--oomol-surface-panel) 100%
+    );
+  }
 }


### PR DESCRIPTION
## Summary

This PR fixes inconsistent dark mode styling across the marketing site and shared surface components.

## What Changed

- corrected page-level dark mode backgrounds and panel surfaces on `/studio`, `/cloud`, `/pricing`, and `/support`
- aligned homepage sections such as first screen, linear flow, Codex Blocks, product comparison, proof layer, developer benefits, pain points, and CLI entry with the design token surface system
- updated shared UI surfaces including cards, outline buttons, popovers, and cookie consent to use semantic surface tokens instead of light-only white mixes

## Why

Several pages and shared components were still mixing in fixed light colors or relying on incomplete dark-mode overrides. That caused panels, cards, and secondary actions to appear too bright or visually inconsistent when `data-theme="dark"` was active.

## Impact

- dark mode visuals are more consistent across key landing pages
- shared surface components now behave more predictably in both light and dark themes
- future theme work should be easier because more surfaces now rely on the existing token system

## Root Cause

The affected styles combined semantic theme tokens with hard-coded light values such as white-heavy gradients and backgrounds. Those values looked acceptable in light mode but leaked into dark mode and broke visual hierarchy.

## Validation

- ran `npm run build`
- verified the build succeeded for both `en` and `zh-CN`
