### PR TITLE
refactor: Improve resize performance by deduplicating global CSS and isolating page  sections

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-pages/privacy/index.tsx
+++ b/i18n/zh-CN/docusaurus-plugin-content-pages/privacy/index.tsx
@@ -1,7 +1,7 @@
 import styles from "./styles.module.scss";
 
-import { MDXProvider } from "@mdx-js/react";
 import Head from "@docusaurus/Head";
+import { MDXProvider } from "@mdx-js/react";
 import Layout from "@theme/Layout";
 import React from "react";
 

--- a/i18n/zh-CN/docusaurus-plugin-content-pages/terms/index.tsx
+++ b/i18n/zh-CN/docusaurus-plugin-content-pages/terms/index.tsx
@@ -1,7 +1,7 @@
 import styles from "./styles.module.scss";
 
-import { MDXProvider } from "@mdx-js/react";
 import Head from "@docusaurus/Head";
+import { MDXProvider } from "@mdx-js/react";
 import Layout from "@theme/Layout";
 import React from "react";
 

--- a/src/components/AssetBlock/styles.module.scss
+++ b/src/components/AssetBlock/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .assetBlock {
   position: relative;
   display: flex;

--- a/src/components/CliPageDeveloperBenefits/styles.module.scss
+++ b/src/components/CliPageDeveloperBenefits/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   padding: clamp(5rem, 10vw, 8rem) 0;
   position: relative;

--- a/src/components/CliPageLinearFlow/styles.module.scss
+++ b/src/components/CliPageLinearFlow/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .flow {
   display: grid;
   gap: 0;

--- a/src/components/CliPagePainPoints/styles.module.scss
+++ b/src/components/CliPagePainPoints/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   padding: clamp(5rem, 10vw, 8rem) 0;
   position: relative;

--- a/src/components/CloudPageFirstScreen/styles.module.scss
+++ b/src/components/CloudPageFirstScreen/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   position: relative;
   overflow: clip;

--- a/src/components/CloudPageLinearFlow/styles.module.scss
+++ b/src/components/CloudPageLinearFlow/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .flow {
   display: grid;
   gap: 0;

--- a/src/components/CloudPagePainPoints/styles.module.scss
+++ b/src/components/CloudPagePainPoints/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   padding: clamp(5rem, 10vw, 8rem) 0;
   position: relative;

--- a/src/components/DownloadsCliPanel/styles.module.scss
+++ b/src/components/DownloadsCliPanel/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .cliSection {
   width: 100%;
   max-width: 100%;

--- a/src/components/HomePageBuiltInLLM/styles.module.scss
+++ b/src/components/HomePageBuiltInLLM/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .container {
   display: flex;
   flex-direction: column;

--- a/src/components/HomePagePricing/index.tsx
+++ b/src/components/HomePagePricing/index.tsx
@@ -1,9 +1,9 @@
 import styles from "./style.module.scss";
 
 import { translate } from "@docusaurus/Translate";
+import { BlurFade } from "@site/src/components/ui/blur-fade";
 import React from "react";
 
-import { BlurFade } from "@site/src/components/ui/blur-fade";
 import { Button } from "../ui/button";
 import {
   Card,

--- a/src/components/HomePagePricing/style.module.scss
+++ b/src/components/HomePagePricing/style.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .container {
   display: flex;
   flex-direction: column;

--- a/src/components/HomepageDownloads/index.tsx
+++ b/src/components/HomepageDownloads/index.tsx
@@ -1,10 +1,10 @@
 import styles from "./styles.module.scss";
 
 import { translate } from "@docusaurus/Translate";
+import { BlurFade } from "@site/src/components/ui/blur-fade";
 import { DownloadUrl } from "@site/src/download_url";
 import React from "react";
 
-import { BlurFade } from "@site/src/components/ui/blur-fade";
 import { Button } from "../ui/button";
 
 type DownloadBtnProps = {

--- a/src/components/HomepageDownloads/styles.module.scss
+++ b/src/components/HomepageDownloads/styles.module.scss
@@ -1,4 +1,4 @@
-@use "../../css/custom.scss" as *;
+@use "../../css/mixins.scss" as *;
 
 .container {
   display: flex;

--- a/src/components/HomepageFirstScreen/styles.module.scss
+++ b/src/components/HomepageFirstScreen/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   position: relative;
   overflow: clip;

--- a/src/components/HomepageGuiEntry/styles.module.scss
+++ b/src/components/HomepageGuiEntry/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   width: 100%;
   padding: clamp(5rem, 10vw, 8rem) 0;

--- a/src/components/HomepageLinearFlow/styles.module.scss
+++ b/src/components/HomepageLinearFlow/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .flow {
   display: grid;
   gap: 0;

--- a/src/components/HomepagePainPoints/styles.module.scss
+++ b/src/components/HomepagePainPoints/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   position: relative;
   padding: clamp(5rem, 10vw, 8rem) 0;

--- a/src/components/HomepagePdfCraftShowcase/styles.module.scss
+++ b/src/components/HomepagePdfCraftShowcase/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   position: relative;
   padding: 120px 24px;

--- a/src/components/HomepageProductComparison/styles.module.scss
+++ b/src/components/HomepageProductComparison/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .comparisonSection {
   padding: clamp(4rem, 8vw, 6rem) 0;
   background: var(--oomol-bg-base);

--- a/src/components/HomepageStarter/styles.module.scss
+++ b/src/components/HomepageStarter/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .sectionStarter {
   width: 100%;
   display: flex;

--- a/src/components/HomepageToolStrip/styles.module.scss
+++ b/src/components/HomepageToolStrip/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   position: relative;
   padding: clamp(4rem, 7vw, 6rem) 0 clamp(4rem, 7vw, 6rem);

--- a/src/components/HomepageWhyOomol/styles.module.scss
+++ b/src/components/HomepageWhyOomol/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   position: relative;
   padding: clamp(5rem, 10vw, 8rem) 0;

--- a/src/components/SiteCta/styles.module.scss
+++ b/src/components/SiteCta/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   width: 100%;
   /* Breathing room before footer while staying on the spotlight band (no body-white strip). */

--- a/src/components/StudioDetailContent/styles.module.scss
+++ b/src/components/StudioDetailContent/styles.module.scss
@@ -1,4 +1,4 @@
-@use "../../css/custom.scss" as *;
+@use "../../css/mixins.scss" as *;
 
 .homeSection {
   padding: clamp(4rem, 8vw, 6rem) 0 clamp(3rem, 6vw, 4.5rem);

--- a/src/components/StudioPdfCraftCase/styles.module.scss
+++ b/src/components/StudioPdfCraftCase/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .section {
   padding: 100px 24px;
   background: var(--oomol-bg-base);

--- a/src/components/magic/copilot-beam-brand-icons.tsx
+++ b/src/components/magic/copilot-beam-brand-icons.tsx
@@ -1,6 +1,7 @@
+import styles from "./copilot-beam-brand-icons.module.scss";
+
 import { useId } from "react";
 
-import styles from "./copilot-beam-brand-icons.module.scss";
 
 /**
  * Brand-colored SaaS marks (inline SVG) for the co-pilot beam hero.

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,5 +1,7 @@
+import type {VariantProps} from "class-variance-authority";
+
 import { cn } from "@site/src/lib/utils";
-import { cva, type VariantProps } from "class-variance-authority";
+import { cva  } from "class-variance-authority";
 import * as React from "react";
 
 const alertVariants = cva(

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,7 +1,7 @@
-import type {VariantProps} from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
 
 import { cn } from "@site/src/lib/utils";
-import { cva  } from "class-variance-authority";
+import { cva } from "class-variance-authority";
 import * as React from "react";
 
 const alertVariants = cva(
@@ -61,7 +61,10 @@ const AlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-oomol-sm leading-[1.55] [&_p]:leading-[1.55]", className)}
+    className={cn(
+      "text-oomol-sm leading-[1.55] [&_p]:leading-[1.55]",
+      className
+    )}
     {...props}
   />
 ));

--- a/src/components/ui/blur-fade.tsx
+++ b/src/components/ui/blur-fade.tsx
@@ -1,12 +1,14 @@
-import { useRef } from "react";
+import type {MotionProps, UseInViewOptions, Variants} from "motion/react";
+
 import {
   AnimatePresence,
   motion,
-  useInView,
-  type MotionProps,
-  type UseInViewOptions,
-  type Variants,
+  useInView
+  
+  
+  
 } from "motion/react";
+import { useRef } from "react";
 
 type MarginType = UseInViewOptions["margin"];
 

--- a/src/components/ui/blur-fade.tsx
+++ b/src/components/ui/blur-fade.tsx
@@ -1,13 +1,6 @@
-import type {MotionProps, UseInViewOptions, Variants} from "motion/react";
+import type { MotionProps, UseInViewOptions, Variants } from "motion/react";
 
-import {
-  AnimatePresence,
-  motion,
-  useInView
-  
-  
-  
-} from "motion/react";
+import { AnimatePresence, motion, useInView } from "motion/react";
 import { useRef } from "react";
 
 type MarginType = UseInViewOptions["margin"];

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,12 +1,11 @@
 import styles from "./button.module.scss";
 
-import type {VariantProps} from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
 
 import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@site/src/lib/utils";
-import { cva  } from "class-variance-authority";
+import { cva } from "class-variance-authority";
 import * as React from "react";
-
 
 /**
  * shadcn/ui Button — tuned to Vercel's marketing-site button system.
@@ -49,9 +48,10 @@ const buttonVariants = cva(
         // Ghost (no border, appears only on hover)
         ghost: styles.variantGhost,
         // Pure underline text link（无线框占位）
-        link: [styles.variantLink, "underline-offset-[3px] h-auto min-h-0 p-0"].join(
-          " "
-        ),
+        link: [
+          styles.variantLink,
+          "underline-offset-[3px] h-auto min-h-0 p-0",
+        ].join(" "),
       },
       size: {
         sm: "h-8 px-3 text-oomol-mono rounded-md",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,9 +1,12 @@
+import styles from "./button.module.scss";
+
+import type {VariantProps} from "class-variance-authority";
+
 import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@site/src/lib/utils";
-import { cva, type VariantProps } from "class-variance-authority";
+import { cva  } from "class-variance-authority";
 import * as React from "react";
 
-import styles from "./button.module.scss";
 
 /**
  * shadcn/ui Button — tuned to Vercel's marketing-site button system.

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -298,14 +298,20 @@ html[lang="en"] {
   [class*="eyebrow"]:not([class*="eyebrowNumber"]):not(
     [class*="eyebrowLabel"]
   ):not([class*="eyebrowDivider"])::before,
-.oomol-home-main [class*="Eyebrow"]::before,
+.oomol-home-main
+  [class*="Eyebrow"]:not([class*="EyebrowNumber"]):not(
+    [class*="EyebrowLabel"]
+  ):not([class*="EyebrowDivider"])::before,
 .oomol-home-main [class*="kicker"]::before,
 .oomol-home-main [class*="Kicker"]::before,
 .oomol-landing-main
   [class*="eyebrow"]:not([class*="eyebrowNumber"]):not(
     [class*="eyebrowLabel"]
   ):not([class*="eyebrowDivider"])::before,
-.oomol-landing-main [class*="Eyebrow"]::before,
+.oomol-landing-main
+  [class*="Eyebrow"]:not([class*="EyebrowNumber"]):not(
+    [class*="EyebrowLabel"]
+  ):not([class*="EyebrowDivider"])::before,
 .oomol-landing-main [class*="kicker"]::before,
 .oomol-landing-main [class*="Kicker"]::before {
   content: "";

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -1,5 +1,6 @@
 @use "./font.scss" as *;
 @use "./design-tokens.scss" as *;
+@use "./mixins.scss" as *;
 
 /* Radix Themes — only for components that opt in (e.g. Cookie preferences Switch). */
 @import "@radix-ui/themes/styles.css";
@@ -134,6 +135,7 @@ html[lang="en"] {
   position: relative;
   isolation: isolate;
   font-family: var(--oomol-font-body);
+  --oomol-page-block-intrinsic-size: 960px;
 
   > section {
     margin-block: 0;
@@ -141,6 +143,42 @@ html[lang="en"] {
 
   > section + section {
     margin-top: 0;
+  }
+}
+
+.oomol-app-page {
+  --oomol-page-block-intrinsic-size: 1200px;
+}
+
+/* Page-level block isolation:
+   resize jank on long marketing pages mostly came from offscreen sections and
+   sibling sections participating in the same lifecycle updates. Isolate each
+   top-level block so offscreen content can be skipped and visible blocks stop
+   invalidating the whole page. */
+@supports (content-visibility: auto) {
+  .oomol-home-main > *,
+  .oomol-landing-main > * {
+    content-visibility: auto;
+    contain: content;
+    contain-intrinsic-size: auto var(--oomol-page-block-intrinsic-size);
+  }
+
+  .oomol-home-main > .oomol-no-section-isolation,
+  .oomol-home-main > :target,
+  .oomol-landing-main > .oomol-no-section-isolation,
+  .oomol-landing-main > :target {
+    content-visibility: visible;
+    contain: none;
+    contain-intrinsic-size: auto;
+  }
+
+  @supports selector(:has(:target)) {
+    .oomol-home-main > :has(:target),
+    .oomol-landing-main > :has(:target) {
+      content-visibility: visible;
+      contain: none;
+      contain-intrinsic-size: auto;
+    }
   }
 }
 
@@ -256,11 +294,17 @@ html[lang="en"] {
   box-shadow: none !important;
 }
 
-.oomol-home-main [class*="eyebrow"]:not([class*="eyebrowNumber"]):not([class*="eyebrowLabel"]):not([class*="eyebrowDivider"])::before,
+.oomol-home-main
+  [class*="eyebrow"]:not([class*="eyebrowNumber"]):not(
+    [class*="eyebrowLabel"]
+  ):not([class*="eyebrowDivider"])::before,
 .oomol-home-main [class*="Eyebrow"]::before,
 .oomol-home-main [class*="kicker"]::before,
 .oomol-home-main [class*="Kicker"]::before,
-.oomol-landing-main [class*="eyebrow"]:not([class*="eyebrowNumber"]):not([class*="eyebrowLabel"]):not([class*="eyebrowDivider"])::before,
+.oomol-landing-main
+  [class*="eyebrow"]:not([class*="eyebrowNumber"]):not(
+    [class*="eyebrowLabel"]
+  ):not([class*="eyebrowDivider"])::before,
 .oomol-landing-main [class*="Eyebrow"]::before,
 .oomol-landing-main [class*="kicker"]::before,
 .oomol-landing-main [class*="Kicker"]::before {
@@ -275,8 +319,10 @@ html[lang="en"] {
 }
 
 /* Badges (非 step 水印里的编号) — 也走 mono pill 但带 hairline */
-.oomol-home-main [class*="badge" i]:not([class*="NoWrap"]):not([class*="noWrap"]),
-.oomol-landing-main [class*="badge" i]:not([class*="NoWrap"]):not([class*="noWrap"]) {
+.oomol-home-main
+  [class*="badge" i]:not([class*="NoWrap"]):not([class*="noWrap"]),
+.oomol-landing-main
+  [class*="badge" i]:not([class*="NoWrap"]):not([class*="noWrap"]) {
   display: inline-flex;
   width: fit-content;
   align-items: center;
@@ -349,7 +395,8 @@ html[lang="en"] {
 
 /* Ring-style legacy badges with uppercase / heavy weight — 统一降权为正常 */
 .oomol-home-main :is([class*="tag" i], [class*="pill" i], [class*="chip" i]),
-.oomol-landing-main :is([class*="tag" i], [class*="pill" i], [class*="chip" i]) {
+.oomol-landing-main
+  :is([class*="tag" i], [class*="pill" i], [class*="chip" i]) {
   text-transform: none;
   font-weight: 500;
   letter-spacing: var(--oomol-tracking-mono);
@@ -453,95 +500,6 @@ html[lang="en"] {
    基于标准的移动优先设计
    ============================================ */
 
-// 标准断点定义
-$breakpoint-xs: 375px; // 小手机
-$breakpoint-sm: 640px; // 大手机
-$breakpoint-md: 768px; // 平板
-$breakpoint-lg: 1024px; // 笔记本
-$breakpoint-xl: 1280px; // 桌面
-$breakpoint-2xl: 1536px; // 大屏幕
-
-// 为了向后兼容，保留旧的变量名作为别名
-$mobile-width: $breakpoint-xs;
-$mobile-middle-width: 390px;
-$mobile-large-width: 430px;
-$tablet-width: $breakpoint-sm;
-$tablet-middle-width: $breakpoint-md;
-$tablet-large-width: 820px;
-$desktop-width: $breakpoint-xl;
-
-// 推荐使用的新 mixin（标准命名）
-@mixin respond-to($breakpoint) {
-  @if $breakpoint == xs {
-    @media (max-width: $breakpoint-xs) {
-      @content;
-    }
-  } @else if $breakpoint == sm {
-    @media (max-width: $breakpoint-sm) {
-      @content;
-    }
-  } @else if $breakpoint == md {
-    @media (max-width: $breakpoint-md) {
-      @content;
-    }
-  } @else if $breakpoint == lg {
-    @media (max-width: $breakpoint-lg) {
-      @content;
-    }
-  } @else if $breakpoint == xl {
-    @media (max-width: $breakpoint-xl) {
-      @content;
-    }
-  } @else if $breakpoint == 2xl {
-    @media (max-width: $breakpoint-2xl) {
-      @content;
-    }
-  }
-}
-
-// 为了向后兼容，保留旧的 mixin
-@mixin phone {
-  @media (max-width: #{$mobile-width}) {
-    @content;
-  }
-}
-
-@mixin phone-middle {
-  @media (max-width: #{$mobile-middle-width}) {
-    @content;
-  }
-}
-
-@mixin phone-large {
-  @media (max-width: #{$mobile-large-width}) {
-    @content;
-  }
-}
-
-@mixin pad {
-  @media (max-width: #{$tablet-width}) {
-    @content;
-  }
-}
-
-@mixin pad-middle {
-  @media (max-width: #{$tablet-middle-width}) {
-    @content;
-  }
-}
-
-@mixin pad-large {
-  @media (max-width: #{$tablet-large-width}) {
-    @content;
-  }
-}
-
-@mixin desktop {
-  @media (max-width: #{$desktop-width}) {
-    @content;
-  }
-}
-
 @media (min-width: 997px) {
   :root {
     // TODO: 替换为新的 Navbar 样式后再恢复该样式
@@ -550,15 +508,6 @@ $desktop-width: $breakpoint-xl;
 
     --ifm-navbar-height: 64px;
   }
-}
-
-/* 副文案：纯色次级色，无渐变（旧名 linearGradientColor 已弃用） */
-@mixin flatSecondaryText {
-  color: var(--oomol-text-secondary);
-  background-image: none;
-  -webkit-background-clip: unset;
-  background-clip: unset;
-  -webkit-text-fill-color: unset;
 }
 
 // 文档页面使用，用于在一行显示多个图片

--- a/src/css/mixins.scss
+++ b/src/css/mixins.scss
@@ -1,0 +1,98 @@
+/* Shared Sass helpers only.
+   Keep this file CSS-output-free so module styles can safely `@use` it. */
+
+// Standard breakpoint definitions
+$breakpoint-xs: 375px; // Small phones
+$breakpoint-sm: 640px; // Large phones
+$breakpoint-md: 768px; // Tablets
+$breakpoint-lg: 1024px; // Laptops
+$breakpoint-xl: 1280px; // Desktop
+$breakpoint-2xl: 1536px; // Large desktop
+
+// Legacy aliases kept for existing modules
+$mobile-width: $breakpoint-xs;
+$mobile-middle-width: 390px;
+$mobile-large-width: 430px;
+$tablet-width: $breakpoint-sm;
+$tablet-middle-width: $breakpoint-md;
+$tablet-large-width: 820px;
+$desktop-width: $breakpoint-xl;
+
+@mixin respond-to($breakpoint) {
+  @if $breakpoint == xs {
+    @media (max-width: $breakpoint-xs) {
+      @content;
+    }
+  } @else if $breakpoint == sm {
+    @media (max-width: $breakpoint-sm) {
+      @content;
+    }
+  } @else if $breakpoint == md {
+    @media (max-width: $breakpoint-md) {
+      @content;
+    }
+  } @else if $breakpoint == lg {
+    @media (max-width: $breakpoint-lg) {
+      @content;
+    }
+  } @else if $breakpoint == xl {
+    @media (max-width: $breakpoint-xl) {
+      @content;
+    }
+  } @else if $breakpoint == 2xl {
+    @media (max-width: $breakpoint-2xl) {
+      @content;
+    }
+  }
+}
+
+@mixin phone {
+  @media (max-width: #{$mobile-width}) {
+    @content;
+  }
+}
+
+@mixin phone-middle {
+  @media (max-width: #{$mobile-middle-width}) {
+    @content;
+  }
+}
+
+@mixin phone-large {
+  @media (max-width: #{$mobile-large-width}) {
+    @content;
+  }
+}
+
+@mixin pad {
+  @media (max-width: #{$tablet-width}) {
+    @content;
+  }
+}
+
+@mixin pad-middle {
+  @media (max-width: #{$tablet-middle-width}) {
+    @content;
+  }
+}
+
+@mixin pad-large {
+  @media (max-width: #{$tablet-large-width}) {
+    @content;
+  }
+}
+
+@mixin desktop {
+  @media (max-width: #{$desktop-width}) {
+    @content;
+  }
+}
+
+/* Secondary copy should stay flat and avoid clipped gradient text. */
+@mixin flatSecondaryText {
+  color: var(--oomol-text-secondary);
+  background-image: none;
+  -webkit-background-clip: unset;
+  background-clip: unset;
+  -webkit-text-fill-color: unset;
+}

--- a/src/pages/brand-assets/styles.module.scss
+++ b/src/pages/brand-assets/styles.module.scss
@@ -1,4 +1,4 @@
-@use "../../css/custom.scss" as *;
+@use "../../css/mixins.scss" as *;
 
 .container {
   display: flex;

--- a/src/pages/contact-us/styles.module.scss
+++ b/src/pages/contact-us/styles.module.scss
@@ -1,4 +1,4 @@
-@use "../../css/custom.scss" as *;
+@use "../../css/mixins.scss" as *;
 
 .container {
   display: flex;

--- a/src/pages/downloads/styles.module.scss
+++ b/src/pages/downloads/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .page {
   background: var(--oomol-bg-base);
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,7 @@
-import Head from "@docusaurus/Head";
+import homeStyles from "./home.module.scss";
+
 import BrowserOnly from "@docusaurus/BrowserOnly";
+import Head from "@docusaurus/Head";
 import { translate } from "@docusaurus/Translate";
 import HomepageFirstScreen from "@site/src/components/HomepageFirstScreen";
 import HomepageLinearFlow from "@site/src/components/HomepageLinearFlow";
@@ -9,7 +11,6 @@ import HomepageWhyOomol from "@site/src/components/HomepageWhyOomol";
 import React from "react";
 
 import Layout from "../theme/Layout";
-import homeStyles from "./home.module.scss";
 
 type PerfSection =
   | "hero"

--- a/src/pages/pricing/styles.module.scss
+++ b/src/pages/pricing/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .page {
   background: var(--oomol-bg-base);
 }

--- a/src/pages/privacy/index.tsx
+++ b/src/pages/privacy/index.tsx
@@ -1,7 +1,7 @@
 import styles from "./styles.module.scss";
 
-import { MDXProvider } from "@mdx-js/react";
 import Head from "@docusaurus/Head";
+import { MDXProvider } from "@mdx-js/react";
 import React from "react";
 
 import Privacy from "./_privacy.mdx";

--- a/src/pages/studio/styles.module.scss
+++ b/src/pages/studio/styles.module.scss
@@ -1,5 +1,3 @@
-@use "../../css/custom.scss" as *;
-
 .page {
   background: var(--oomol-bg-base);
 }

--- a/src/pages/terms/index.tsx
+++ b/src/pages/terms/index.tsx
@@ -1,7 +1,7 @@
 import styles from "./styles.module.scss";
 
-import { MDXProvider } from "@mdx-js/react";
 import Head from "@docusaurus/Head";
+import { MDXProvider } from "@mdx-js/react";
 import React from "react";
 
 import Terms from "./_terms.mdx";

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -190,10 +190,6 @@ const Footer: React.FC = () => {
                   role="button"
                   tabIndex={0}
                   aria-label="WeChat QR code"
-                  // onMouseEnter={() => setIsHovered(true)}
-                  // onMouseLeave={() => setIsHovered(false)}
-                  // onFocus={() => setIsHovered(true)}
-                  // onBlur={() => setIsHovered(false)}
                 >
                   <i
                     className={clsx("i-simple-icons-wechat", styles.socialIcon)}

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -8,7 +8,7 @@ import { Popover } from "@site/src/components/Popover";
 import { Button } from "@site/src/components/ui/button";
 import ThemedImage from "@theme/ThemedImage";
 import { clsx } from "clsx";
-import React, { useState, useMemo } from "react";
+import React, { useMemo } from "react";
 
 import { ColorModeDropdown } from "../components/ColorModeDropdown";
 import { LocalDropdown } from "../components/LocalDropdown";
@@ -128,7 +128,7 @@ const Footer: React.FC = () => {
   const { copyright, links = [] } = siteConfig.themeConfig.footer;
   const hasFooter = !!siteConfig.themeConfig.footer;
   const currentLocale = i18n.currentLocale;
-  const [isHovered, setIsHovered] = useState(false);
+
   const logoLight = useBaseUrl(
     `/img/logo-${currentLocale === "zh-CN" ? "zh" : "en"}-light.svg`
   );
@@ -190,16 +190,13 @@ const Footer: React.FC = () => {
                   role="button"
                   tabIndex={0}
                   aria-label="WeChat QR code"
-                  onMouseEnter={() => setIsHovered(true)}
-                  onMouseLeave={() => setIsHovered(false)}
-                  onFocus={() => setIsHovered(true)}
-                  onBlur={() => setIsHovered(false)}
+                  // onMouseEnter={() => setIsHovered(true)}
+                  // onMouseLeave={() => setIsHovered(false)}
+                  // onFocus={() => setIsHovered(true)}
+                  // onBlur={() => setIsHovered(false)}
                 >
                   <i
-                    className={clsx(
-                      "i-simple-icons-wechat",
-                      styles.socialIcon
-                    )}
+                    className={clsx("i-simple-icons-wechat", styles.socialIcon)}
                     aria-hidden="true"
                   />
                 </div>

--- a/src/theme/Footer/styles.module.scss
+++ b/src/theme/Footer/styles.module.scss
@@ -1,4 +1,4 @@
-@use "../../css/custom.scss" as *;
+@use "../../css/mixins.scss" as *;
 
 /* Same runway as SiteCta: spotlight band. Use padding (not margin-top) so no body-white “sandwich” gap. */
 .root {

--- a/tests/eyebrow-bullet-exclusions.mjs
+++ b/tests/eyebrow-bullet-exclusions.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const customScssPath = path.resolve(process.cwd(), "src/css/custom.scss");
+const source = readFileSync(customScssPath, "utf8");
+
+function normalizeCss(text) {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\s+/g, " ")
+    .replace(/\s*([:;,{}()])\s*/g, "$1")
+    .trim();
+}
+
+const normalizedSource = normalizeCss(source);
+
+for (const pageClass of [".oomol-home-main", ".oomol-landing-main"]) {
+  assert.ok(
+    normalizedSource.includes(
+      `${pageClass} [class*="Eyebrow"]:not([class*="EyebrowNumber"]):not([class*="EyebrowLabel"]):not([class*="EyebrowDivider"])::before`
+    ),
+    `Expected ${pageClass} Eyebrow bullet selector to exclude Number/Label/Divider variants.`
+  );
+}
+
+console.log(
+  "Eyebrow bullet exclusions are present for home and landing pages."
+);

--- a/tests/no-custom-scss-imports.mjs
+++ b/tests/no-custom-scss-imports.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const srcDir = path.resolve(process.cwd(), "src");
+const allowedImporters = new Set([path.join("src", "css", "custom.scss")]);
+const styleExtensions = new Set([".css", ".scss"]);
+const offenders = [];
+
+function walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath);
+      continue;
+    }
+
+    if (!styleExtensions.has(path.extname(entry.name))) {
+      continue;
+    }
+
+    const relativePath = path.relative(process.cwd(), fullPath);
+    const source = readFileSync(fullPath, "utf8");
+    const importsCustomScss =
+      /@use\s+["'][^"']*custom\.scss["']\s+as\s+\*/.test(source);
+
+    if (importsCustomScss && !allowedImporters.has(relativePath)) {
+      offenders.push(relativePath);
+    }
+  }
+}
+
+walk(srcDir);
+
+assert.equal(
+  offenders.length,
+  0,
+  [
+    "Style modules must not import src/css/custom.scss directly.",
+    "custom.scss emits global CSS, so importing it from modules duplicates the entire stylesheet bundle.",
+    "",
+    "Offending files:",
+    ...offenders.map(file => `- ${file}`),
+  ].join("\n")
+);
+
+console.log("No style modules import src/css/custom.scss directly.");

--- a/tests/no-unused-mixins-imports.mjs
+++ b/tests/no-unused-mixins-imports.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const projectRoot = process.cwd();
+const srcDir = path.resolve(projectRoot, "src");
+const mixinsPath = path.resolve(srcDir, "css/mixins.scss");
+const mixinsSource = readFileSync(mixinsPath, "utf8");
+const mixinsImportStatement = '@use "../../css/mixins.scss" as *;';
+
+const mixinNames = [...mixinsSource.matchAll(/@mixin\s+([A-Za-z0-9_-]+)/g)].map(
+  match => match[1]
+);
+const variableNames = [...mixinsSource.matchAll(/^\$([A-Za-z0-9_-]+):/gm)].map(
+  match => match[1]
+);
+
+const helperUsagePatterns = [
+  ...mixinNames.map(name => ({
+    kind: "mixin",
+    name,
+    pattern: new RegExp(`@include\\s+${escapeRegExp(name)}\\b`),
+  })),
+  ...variableNames.map(name => ({
+    kind: "variable",
+    name,
+    pattern: new RegExp(`\\$${escapeRegExp(name)}\\b`),
+  })),
+];
+
+const offenders = [];
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function stripComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+}
+
+function walk(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      walk(fullPath);
+      continue;
+    }
+
+    if (!entry.name.endsWith(".scss")) {
+      continue;
+    }
+
+    const relativePath = path.relative(projectRoot, fullPath);
+    const source = readFileSync(fullPath, "utf8");
+
+    if (!source.includes(mixinsImportStatement)) {
+      continue;
+    }
+
+    const strippedSource = stripComments(
+      source.replace(mixinsImportStatement, "")
+    );
+    const matchedHelper = helperUsagePatterns.find(({ pattern }) =>
+      pattern.test(strippedSource)
+    );
+
+    if (!matchedHelper) {
+      offenders.push(relativePath);
+    }
+  }
+}
+
+walk(srcDir);
+
+assert.equal(
+  offenders.length,
+  0,
+  [
+    "Some style modules import src/css/mixins.scss without using any exported Sass helper.",
+    "Remove the unused @use to keep module dependencies explicit and avoid cargo-cult imports.",
+    "",
+    "Offending files:",
+    ...offenders.map(file => `- ${file}`),
+  ].join("\n")
+);
+
+console.log(
+  "All src/css/mixins.scss imports are backed by actual Sass helper usage."
+);

--- a/tests/page-section-anchor-targets.mjs
+++ b/tests/page-section-anchor-targets.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const customScssPath = path.resolve(process.cwd(), "src/css/custom.scss");
+const appPagePath = path.resolve(process.cwd(), "src/pages/app/index.tsx");
+const customSource = readFileSync(customScssPath, "utf8");
+const appPageSource = readFileSync(appPagePath, "utf8");
+
+function readBlock(source, header) {
+  const headerIndex = source.indexOf(header);
+  assert.notEqual(headerIndex, -1, `Expected to find block header: ${header}`);
+
+  const openBraceIndex = source.indexOf("{", headerIndex + header.length);
+  assert.notEqual(openBraceIndex, -1, `Expected ${header} to open a block.`);
+
+  let depth = 1;
+
+  for (let index = openBraceIndex + 1; index < source.length; index += 1) {
+    const char = source[index];
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(openBraceIndex + 1, index);
+      }
+    }
+  }
+
+  throw new Error(`Expected ${header} to close its block.`);
+}
+
+function readRuleBlock(source, selector) {
+  const selectorIndex = source.indexOf(selector);
+  assert.notEqual(selectorIndex, -1, `Expected to find selector: ${selector}`);
+
+  const openBraceIndex = source.indexOf("{", selectorIndex + selector.length);
+  assert.notEqual(openBraceIndex, -1, `Expected ${selector} to open a rule.`);
+
+  let depth = 1;
+
+  for (let index = openBraceIndex + 1; index < source.length; index += 1) {
+    const char = source[index];
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return source.slice(openBraceIndex + 1, index);
+      }
+    }
+  }
+
+  throw new Error(`Expected ${selector} to close its rule.`);
+}
+
+function normalizeCss(text) {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\s+/g, " ")
+    .replace(/\s*([:;,{}])\s*/g, "$1")
+    .trim();
+}
+
+function assertDeclaration(ruleBlock, property, value, message) {
+  const normalizedRuleBlock = normalizeCss(ruleBlock);
+  assert.ok(
+    normalizedRuleBlock.includes(`${property}:${value}`),
+    message ?? `Expected declaration ${property}: ${value}.`
+  );
+}
+
+assert.match(
+  appPageSource,
+  /<section[\s\S]*?id="models-demo"[\s\S]*?<h2 id="models-demo-heading"/,
+  "Expected a nested hash target canary inside src/pages/app/index.tsx."
+);
+
+const contentVisibilitySupportBlock = readBlock(
+  customSource,
+  "@supports (content-visibility: auto)"
+);
+const hasTargetSupportBlock = readBlock(
+  contentVisibilitySupportBlock,
+  "@supports selector(:has(:target))"
+);
+
+assert.ok(
+  hasTargetSupportBlock.includes(".oomol-home-main > :has(:target)"),
+  "Expected oomol-home-main deep :target opt-out selector."
+);
+assert.ok(
+  hasTargetSupportBlock.includes(".oomol-landing-main > :has(:target)"),
+  "Expected oomol-landing-main deep :target opt-out selector."
+);
+
+const deepTargetOptOutRule = readRuleBlock(
+  hasTargetSupportBlock,
+  ".oomol-home-main > :has(:target)"
+);
+
+assertDeclaration(
+  deepTargetOptOutRule,
+  "content-visibility",
+  "visible",
+  "Expected deep :target sections to disable content-visibility."
+);
+assertDeclaration(
+  deepTargetOptOutRule,
+  "contain",
+  "none",
+  "Expected deep :target sections to drop contain: content."
+);
+assertDeclaration(
+  deepTargetOptOutRule,
+  "contain-intrinsic-size",
+  "auto",
+  "Expected deep :target sections to drop synthetic intrinsic size."
+);
+
+console.log(
+  "Deep hash targets stay opt-out capable under page-section isolation."
+);

--- a/tests/page-section-isolation.mjs
+++ b/tests/page-section-isolation.mjs
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const customScssPath = path.resolve(process.cwd(), "src/css/custom.scss");
+const source = readFileSync(customScssPath, "utf8");
+
+function readBlock(sourceText, header) {
+  const headerIndex = sourceText.indexOf(header);
+  assert.notEqual(headerIndex, -1, `Expected to find block header: ${header}`);
+
+  const openBraceIndex = sourceText.indexOf("{", headerIndex + header.length);
+  assert.notEqual(openBraceIndex, -1, `Expected ${header} to open a block.`);
+
+  let depth = 1;
+
+  for (let index = openBraceIndex + 1; index < sourceText.length; index += 1) {
+    const char = sourceText[index];
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return sourceText.slice(openBraceIndex + 1, index);
+      }
+    }
+  }
+
+  throw new Error(`Expected ${header} to close its block.`);
+}
+
+function readRuleBlock(sourceText, selector) {
+  const selectorIndex = sourceText.indexOf(selector);
+  assert.notEqual(
+    selectorIndex,
+    -1,
+    `Expected to find selector in custom.scss: ${selector}`
+  );
+
+  const openBraceIndex = sourceText.indexOf(
+    "{",
+    selectorIndex + selector.length
+  );
+  assert.notEqual(openBraceIndex, -1, `Expected ${selector} to open a rule.`);
+
+  let depth = 1;
+
+  for (let index = openBraceIndex + 1; index < sourceText.length; index += 1) {
+    const char = sourceText[index];
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return sourceText.slice(openBraceIndex + 1, index);
+      }
+    }
+  }
+
+  throw new Error(`Expected ${selector} to close its rule.`);
+}
+
+function normalizeCss(text) {
+  return text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\s+/g, " ")
+    .replace(/\s*([:;,{}])\s*/g, "$1")
+    .trim();
+}
+
+function assertDeclaration(ruleBlock, property, value, message) {
+  const normalizedRuleBlock = normalizeCss(ruleBlock);
+  assert.ok(
+    normalizedRuleBlock.includes(`${property}:${value}`),
+    message ?? `Expected declaration ${property}: ${value}.`
+  );
+}
+
+const contentVisibilitySupportBlock = readBlock(
+  source,
+  "@supports (content-visibility: auto)"
+);
+
+const isolatedSectionsRule = readRuleBlock(
+  contentVisibilitySupportBlock,
+  ".oomol-home-main > *"
+);
+
+assert.ok(
+  contentVisibilitySupportBlock.includes(".oomol-home-main > *"),
+  "Expected oomol-home-main direct children to participate in section isolation."
+);
+assert.ok(
+  contentVisibilitySupportBlock.includes(".oomol-landing-main > *"),
+  "Expected oomol-landing-main direct children to participate in section isolation."
+);
+assertDeclaration(
+  isolatedSectionsRule,
+  "content-visibility",
+  "auto",
+  "Expected section isolation to use content-visibility: auto."
+);
+assertDeclaration(
+  isolatedSectionsRule,
+  "contain",
+  "content",
+  "Expected section isolation to use contain: content."
+);
+assertDeclaration(
+  isolatedSectionsRule,
+  "contain-intrinsic-size",
+  "auto var(--oomol-page-block-intrinsic-size)",
+  "Expected section isolation to keep a stable intrinsic size fallback."
+);
+
+const optOutRule = readRuleBlock(
+  contentVisibilitySupportBlock,
+  ".oomol-home-main > .oomol-no-section-isolation"
+);
+
+assert.ok(
+  contentVisibilitySupportBlock.includes(
+    ".oomol-home-main > .oomol-no-section-isolation"
+  ),
+  "Expected oomol-home-main to expose a section-isolation opt-out class."
+);
+assert.ok(
+  contentVisibilitySupportBlock.includes(".oomol-home-main > :target"),
+  "Expected oomol-home-main direct hash targets to opt out of section isolation."
+);
+assert.ok(
+  contentVisibilitySupportBlock.includes(
+    ".oomol-landing-main > .oomol-no-section-isolation"
+  ),
+  "Expected oomol-landing-main to expose a section-isolation opt-out class."
+);
+assert.ok(
+  contentVisibilitySupportBlock.includes(".oomol-landing-main > :target"),
+  "Expected oomol-landing-main direct hash targets to opt out of section isolation."
+);
+assertDeclaration(
+  optOutRule,
+  "content-visibility",
+  "visible",
+  "Expected isolation opt-outs to restore content visibility."
+);
+assertDeclaration(
+  optOutRule,
+  "contain",
+  "none",
+  "Expected isolation opt-outs to drop contain: content."
+);
+assertDeclaration(
+  optOutRule,
+  "contain-intrinsic-size",
+  "auto",
+  "Expected isolation opt-outs to drop the synthetic intrinsic size."
+);
+
+console.log("Page-section isolation rules are present in custom.scss.");


### PR DESCRIPTION
- Removed `@use "../../css/custom.scss" as *;` from various components and pages.
- Updated imports to `@use "../../css/mixins.scss" as *;` where applicable.
- Introduced a new mixins.scss file to centralize shared Sass helpers and break dependencies on custom.scss.
- Added tests to ensure no components import custom.scss directly and that all mixins are utilized correctly.
