### PR TITLE
[codex] Remove internal-facing homepage copy

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -30,7 +30,7 @@
     "message": "OOMOL - A CLI that turns apps into tools for agents"
   },
   "HOME.page.description": {
-    "message": "Start with oo-cli so Codex, OpenClaw, Claude Code, and other agents can use ready-made tools, APIs, and internal capabilities to get real work moving. When you need to build, combine, and deliver your own tools, move into OOMOL Studio and Cloud."
+    "message": "Start with oo-cli so Codex, OpenClaw, Claude Code, and other agents can use ready-made tools, APIs, and business systems to get real work moving. When you need to build, combine, and deliver your own tools, move into OOMOL Studio and Cloud."
   },
   "HOME.FirstScreen.slogan": {
     "message": "Build and Deliver Tools for Agents"
@@ -42,7 +42,7 @@
     "message": "Your agent does the thinking\nand decision-making.\nLeave the rest to OOMOL."
   },
   "HOME.FirstScreen.heroLead": {
-    "message": "Start with oo-cli so agents can use ready-made tools, APIs, and internal capabilities to get work moving. When those are not enough, move into Studio and Cloud."
+    "message": "Let Codex, OpenClaw, Claude Code, and other agents directly use tools like Gmail and Notion, plus APIs and business systems. Then use OOMOL Studio to compose and extend your own tools."
   },
   "HOME.FirstScreen.video.playAriaLabel": {
     "message": "Play demo video"
@@ -87,7 +87,7 @@
     "message": "Extract requirements, shape tasks, and write them back to Linear."
   },
   "HOME.PainPoints.card3.title": {
-    "message": "Read a Gmail attachment, then call an internal API"
+    "message": "Read a Gmail attachment, then call your API"
   },
   "HOME.PainPoints.card3.description": {
     "message": "Useful when you want to pipe email inputs straight into your own service."
@@ -96,7 +96,7 @@
     "message": "Read the Gmail attachment, call our PDF API, and return the result."
   },
   "HOME.PainPoints.card3.solution": {
-    "message": "Download the attachment, call your internal API, and return the output."
+    "message": "Download the attachment, call your API, and return the output."
   },
   "HOME.PainPoints.card3.apiLabel": {
     "message": "Your API"
@@ -159,7 +159,7 @@
     "message": "Workflow walkthrough"
   },
   "HOME.FirstScreen.workflowArchive.lead": {
-    "message": "Full demo video, kept here for reuse."
+    "message": "A full demo video that walks through the workflow from generation to execution."
   },
   "HOME.CoreFeatures.title": {
     "message": "What Makes “Function-to-Delivery” Actually Work"
@@ -2047,7 +2047,7 @@
     "message": "When you need your own APIs and logic, move into Studio + Cloud"
   },
   "HOME.DeveloperBenefits.card2.description": {
-    "message": "When ready-made tools are not enough, use Studio + Cloud to add your APIs, internal logic, and a long-running delivery path."
+    "message": "When ready-made tools are not enough, use Studio + Cloud to add your APIs, custom logic, and a long-running delivery path."
   },
   "HOME.DeveloperBenefits.card2.note": {
     "message": "Best when you need custom tools and continuous delivery."
@@ -2743,7 +2743,7 @@
     "message": "Write new function tools directly"
   },
   "HOME.DeveloperEntry.card3.text": {
-    "message": "When existing wrappers are not enough, write new function tools and bring in your own APIs, internal systems, and business logic."
+    "message": "When existing wrappers are not enough, write new function tools and bring in your own APIs, business systems, and business logic."
   },
   "HOME.DeveloperEntry.card4.title": {
     "message": "Move the new tool into the delivery path"

--- a/i18n/zh-CN/code.json
+++ b/i18n/zh-CN/code.json
@@ -30,7 +30,7 @@
     "message": "OOMOL - 一个让 AI Agent 调用现成工具的 CLI 入口"
   },
   "HOME.page.description": {
-    "message": "先用 oo-cli 让 Codex、OpenClaw、Claude Code 等 Agent 直接调用现成工具、API 和内部能力，把工作先跑起来；当你需要自己生产、组合和交付工具时，再进入 OOMOL Studio 和 Cloud。"
+    "message": "先用 oo-cli 让 Codex、OpenClaw、Claude Code 等 Agent 直接调用现成工具、API 和业务系统，把工作先跑起来；当你需要自己生产、组合和交付工具时，再进入 OOMOL Studio 和 Cloud。"
   },
   "HOME.FirstScreen.slogan": {
     "message": "先用起来，再按需连接"
@@ -42,7 +42,7 @@
     "message": "你的 Agent 负责思考与决策\n剩下的交给 OOMOL"
   },
   "HOME.FirstScreen.heroLead": {
-    "message": "先用 oo-cli 让 Agent 接上现成工具、API 和内部能力，把工作先跑起来；当现成能力不够时，再进入 Studio 和 Cloud。"
+    "message": "让 Codex、OpenClaw、Claude Code 等 Agent 直接调用 Gmail、Notion 等工具、API 和业务系统。用 OOMOL Studio 继续组合和扩展自己的工具。"
   },
   "HOME.FirstScreen.video.playAriaLabel": {
     "message": "播放演示视频"
@@ -87,7 +87,7 @@
     "message": "提取需求、整理任务、写回 Linear。"
   },
   "HOME.PainPoints.card3.title": {
-    "message": "读取 Gmail 附件，再调用内部 API"
+    "message": "读取 Gmail 附件，再调用你的 API"
   },
   "HOME.PainPoints.card3.description": {
     "message": "适合把邮件输入直接接到你的服务，省掉人工中转。"
@@ -96,7 +96,7 @@
     "message": "读 Gmail 附件，调用我们的 PDF API，回传结果。"
   },
   "HOME.PainPoints.card3.solution": {
-    "message": "下载附件、调用内部 API、返回处理结果。"
+    "message": "下载附件、调用你的 API、返回处理结果。"
   },
   "HOME.PainPoints.card3.apiLabel": {
     "message": "你的 API"
@@ -159,7 +159,7 @@
     "message": "工作流演示"
   },
   "HOME.FirstScreen.workflowArchive.lead": {
-    "message": "完整演示视频（原首页主视觉素材），暂置于此便于以后组合。"
+    "message": "完整演示视频，展示从生成到运行的完整工作流。"
   },
   "HOME.CoreFeatures.title": {
     "message": "一份业务代码，直接走到交付"
@@ -2047,7 +2047,7 @@
     "message": "需要自己的 API 和逻辑时，再进入 Studio + Cloud"
   },
   "HOME.DeveloperBenefits.card2.description": {
-    "message": "当你需要接自己的 API、内部逻辑和长期交付路径时，再进入 Studio + Cloud。"
+    "message": "当你需要接自己的 API、自有逻辑和长期交付路径时，再进入 Studio + Cloud。"
   },
   "HOME.DeveloperBenefits.card2.note": {
     "message": "适合开始做自己的工具和持续交付。"
@@ -2743,7 +2743,7 @@
     "message": "直接编写新的函数工具"
   },
   "HOME.DeveloperEntry.card3.text": {
-    "message": "当现有封装不够用时，直接写新的 function tool，把你自己的 API、内部系统和逻辑接进来。"
+    "message": "当现有封装不够用时，直接写新的 function tool，把你自己的 API、业务系统和逻辑接进来。"
   },
   "HOME.DeveloperEntry.card4.title": {
     "message": "让新工具继续进入交付路径"

--- a/src/components/HomepagePainPoints/index.tsx
+++ b/src/components/HomepagePainPoints/index.tsx
@@ -80,7 +80,7 @@ export default function HomepagePainPoints() {
       {
         title: translate({
           id: "HOME.PainPoints.card3.title",
-          message: "Read a Gmail attachment, then call an internal API",
+          message: "Read a Gmail attachment, then call your API",
         }),
         description: translate({
           id: "HOME.PainPoints.card3.description",
@@ -95,7 +95,7 @@ export default function HomepagePainPoints() {
         result: translate({
           id: "HOME.PainPoints.card3.solution",
           message:
-            "Download the attachment, call your internal API, and return the output.",
+            "Download the attachment, call your API, and return the output.",
         }),
         apps: [
           { icon: "i-simple-icons-gmail", label: "Gmail" },

--- a/src/components/HomepageWhyOomol/index.tsx
+++ b/src/components/HomepageWhyOomol/index.tsx
@@ -63,7 +63,7 @@ export default function HomepageWhyOomol() {
         text: translate({
           id: "HOME.DeveloperEntry.card3.text",
           message:
-            "When existing wrappers are not enough, write new function tools and bring in your own APIs, internal systems, and business logic.",
+            "When existing wrappers are not enough, write new function tools and bring in your own APIs, business systems, and business logic.",
         }),
       },
       {


### PR DESCRIPTION
## What changed
- restored the homepage hero lead copy to the more concrete external-facing messaging in both Chinese and English
- replaced internal-facing phrases such as `internal API`, `internal systems`, and the homepage video reuse note with user-facing wording
- aligned the homepage translation strings and component fallback copy so the public site does not leak implementation notes

## Why
Some homepage and marketing copy had drifted into implementation-oriented language that reads like internal notes rather than public product messaging. This PR removes that language before release.

## Impact
- homepage copy is clearer for end users and safer to publish directly
- Chinese and English hero copy stay aligned on the restored messaging
- marketing examples still describe the same capabilities without exposing internal terminology

## Validation
- `npm run typecheck`
- `npm run build`