### PR TITLE
[codex] Remove workflow archive lead copy

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -158,9 +158,6 @@
   "HOME.FirstScreen.workflowArchive.title": {
     "message": "Workflow walkthrough"
   },
-  "HOME.FirstScreen.workflowArchive.lead": {
-    "message": "A full demo video that walks through the workflow from generation to execution."
-  },
   "HOME.CoreFeatures.title": {
     "message": "What Makes “Function-to-Delivery” Actually Work"
   },

--- a/i18n/zh-CN/code.json
+++ b/i18n/zh-CN/code.json
@@ -158,9 +158,6 @@
   "HOME.FirstScreen.workflowArchive.title": {
     "message": "工作流演示"
   },
-  "HOME.FirstScreen.workflowArchive.lead": {
-    "message": "完整演示视频，展示从生成到运行的完整工作流。"
-  },
   "HOME.CoreFeatures.title": {
     "message": "一份业务代码，直接走到交付"
   },

--- a/src/components/HomepageFirstScreen/index.tsx
+++ b/src/components/HomepageFirstScreen/index.tsx
@@ -78,9 +78,6 @@ export default function HomepageFirstScreen() {
           <h2 className={styles.workflowArchiveTitle}>
             {translate({ message: "HOME.FirstScreen.workflowArchive.title" })}
           </h2>
-          <p className={styles.workflowArchiveLead}>
-            {translate({ message: "HOME.FirstScreen.workflowArchive.lead" })}
-          </p>
           <HomepageFirstScreenVideoHero />
         </div>
       </div>

--- a/src/components/HomepageFirstScreen/styles.module.scss
+++ b/src/components/HomepageFirstScreen/styles.module.scss
@@ -92,14 +92,6 @@
   color: var(--oomol-text-primary);
 }
 
-.workflowArchiveLead {
-  margin: 0;
-  max-width: 40rem;
-  font-size: var(--oomol-body-base);
-  line-height: var(--oomol-line-height-relaxed);
-  color: var(--oomol-text-secondary);
-}
-
 /* Hero CTAs — styling comes from the Button component; no overrides needed. */
 
 /* ── 视频展示区 — hairline frame，无阴影光晕 ── */
@@ -322,10 +314,6 @@
 
   .workflowArchiveTitle {
     font-size: var(--oomol-font-size-lg);
-  }
-
-  .workflowArchiveLead {
-    font-size: var(--oomol-body-sm);
   }
 }
 


### PR DESCRIPTION
## What changed
- removed the extra lead paragraph under the homepage "Workflow walkthrough / 工作流演示" section
- deleted the unused `HOME.FirstScreen.workflowArchive.lead` translation key from both English and Chinese locale files
- removed the now-unused `workflowArchiveLead` styles

## Why
The sentence under the section title was redundant. The requested change was to remove it rather than rewrite it.

## User impact
The homepage workflow demo block now shows only the section title and the video hero, which makes the section cleaner and matches the intended copy.

## Root cause
The section still rendered a descriptive lead paragraph even though that copy was no longer needed.

## Validation
- ran `npm run build`
- verified both `build/` and `build/zh-CN/` completed successfully