### PR TITLE
[codex] Remove workflow archive heading and divider

### DIFF
--- a/i18n/en/code.json
+++ b/i18n/en/code.json
@@ -155,9 +155,6 @@
   "HOME.FirstScreen.flow.cloud": {
     "message": "Cloud"
   },
-  "HOME.FirstScreen.workflowArchive.title": {
-    "message": "Workflow walkthrough"
-  },
   "HOME.CoreFeatures.title": {
     "message": "What Makes “Function-to-Delivery” Actually Work"
   },

--- a/i18n/zh-CN/code.json
+++ b/i18n/zh-CN/code.json
@@ -155,9 +155,6 @@
   "HOME.FirstScreen.flow.cloud": {
     "message": "Cloud"
   },
-  "HOME.FirstScreen.workflowArchive.title": {
-    "message": "工作流演示"
-  },
   "HOME.CoreFeatures.title": {
     "message": "一份业务代码，直接走到交付"
   },

--- a/src/components/HomepageFirstScreen/index.tsx
+++ b/src/components/HomepageFirstScreen/index.tsx
@@ -75,9 +75,6 @@ export default function HomepageFirstScreen() {
         */}
 
         <div className={styles.workflowArchive}>
-          <h2 className={styles.workflowArchiveTitle}>
-            {translate({ message: "HOME.FirstScreen.workflowArchive.title" })}
-          </h2>
           <HomepageFirstScreenVideoHero />
         </div>
       </div>

--- a/src/components/HomepageFirstScreen/styles.module.scss
+++ b/src/components/HomepageFirstScreen/styles.module.scss
@@ -77,19 +77,6 @@
 
 .workflowArchive {
   margin-top: clamp(2.5rem, 5vw, 3.5rem);
-  padding-top: clamp(1.5rem, 3vw, 2rem);
-  border-top: 1px solid var(--oomol-divider);
-  display: grid;
-  gap: 0.65rem;
-}
-
-.workflowArchiveTitle {
-  margin: 0;
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-font-size-xl);
-  font-weight: 600;
-  letter-spacing: var(--oomol-tracking-section);
-  color: var(--oomol-text-primary);
 }
 
 /* Hero CTAs — styling comes from the Button component; no overrides needed. */
@@ -308,12 +295,6 @@
 
   .workflowArchive {
     margin-top: 2rem;
-    padding-top: 1.25rem;
-    gap: 0.55rem;
-  }
-
-  .workflowArchiveTitle {
-    font-size: var(--oomol-font-size-lg);
   }
 }
 


### PR DESCRIPTION
## What changed
- removed the homepage workflow demo section heading
- removed the top divider line and its related spacing from the workflow demo wrapper
- deleted the now-unused `HOME.FirstScreen.workflowArchive.title` translation key from both English and Chinese locale files
- removed the now-unused `workflowArchiveTitle` styles

## Why
After the previous copy removal, the section still showed a standalone heading and divider above the video. The requested behavior is to remove both and leave only the video content.

## User impact
The homepage first-screen workflow demo area now renders without the extra heading or divider, so the video sits directly under the hero content.

## Root cause
The wrapper still kept its section title and border-top styling even after the descriptive lead copy was removed.

## Validation
- ran `npm run build`
- verified both `build/` and `build/zh-CN/` completed successfully