### PR TITLE
[codex] Fix mobile homepage layout and navbar

### DIFF
--- a/src/components/CloudPageLinearFlow/styles.module.scss
+++ b/src/components/CloudPageLinearFlow/styles.module.scss
@@ -23,8 +23,11 @@
 .container {
   position: relative;
   z-index: 1;
-  width: min(1200px, calc(100% - 48px));
+  width: 100%;
+  max-width: 1200px;
   margin: 0 auto;
+  padding-inline: 24px;
+  box-sizing: border-box;
   display: grid;
   grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
   gap: clamp(2rem, 4vw, 3.4rem);
@@ -36,6 +39,7 @@
   gap: 1.1rem;
   align-content: start;
   max-width: 34rem;
+  min-width: 0;
 }
 
 /* Mono eyebrow */
@@ -71,6 +75,7 @@
   font-weight: 600;
   color: var(--oomol-text-primary);
   text-wrap: balance;
+  overflow-wrap: anywhere;
 }
 
 .sectionDescription {
@@ -80,6 +85,7 @@
   line-height: var(--oomol-line-height-relaxed);
   letter-spacing: var(--oomol-tracking-body);
   color: var(--oomol-text-secondary);
+  overflow-wrap: anywhere;
 }
 
 /* Inline action links */
@@ -95,15 +101,18 @@
 .secondaryLink {
   display: inline-flex;
   align-items: center;
+  max-width: 100%;
   gap: 0.3rem;
   font-size: var(--oomol-body-base);
   font-weight: 500;
   color: var(--oomol-text-primary);
   text-decoration: none;
   transition: color 0.15s ease;
+  overflow-wrap: anywhere;
 
   &::after {
     content: "→";
+    flex: 0 0 auto;
     color: var(--oomol-text-tertiary);
     transition: transform 0.15s ease;
   }
@@ -141,6 +150,7 @@
   overflow: hidden;
   background: var(--oomol-bg-base);
   margin-top: 0.4rem;
+  min-width: 0;
 }
 
 .cloudCard {
@@ -150,6 +160,7 @@
   background: transparent;
   box-shadow: none !important;
   transition: background-color 0.18s ease;
+  min-width: 0;
 
   &:not(:last-child) {
     border-bottom: 1px solid var(--oomol-divider);
@@ -167,6 +178,7 @@
   font-weight: 600;
   letter-spacing: -0.01em;
   color: var(--oomol-text-primary);
+  overflow-wrap: anywhere;
 }
 
 .cloudText {
@@ -174,6 +186,7 @@
   font-size: var(--oomol-body-sm);
   line-height: 1.58;
   color: var(--oomol-text-secondary);
+  overflow-wrap: anywhere;
 }
 
 /* Media panel — hairline frame */
@@ -184,6 +197,7 @@
   box-shadow: none;
   overflow: hidden;
   min-height: clamp(20rem, 36vw, 30rem);
+  min-width: 0;
 }
 
 .videoCard {
@@ -191,6 +205,7 @@
   min-height: inherit;
   display: grid;
   grid-template-rows: 1fr auto;
+  min-width: 0;
 }
 
 .videoCardMedia,
@@ -222,6 +237,7 @@
   padding: 1rem 1.2rem 1.15rem;
   border-top: 1px solid var(--oomol-divider);
   background: var(--oomol-bg-base);
+  min-width: 0;
 }
 
 .videoCardTitle {
@@ -231,6 +247,7 @@
   line-height: 1.35;
   letter-spacing: -0.01em;
   color: var(--oomol-text-primary);
+  overflow-wrap: anywhere;
 }
 
 .videoCardNote {
@@ -238,6 +255,7 @@
   font-size: var(--oomol-body-sm);
   line-height: 1.56;
   color: var(--oomol-text-tertiary);
+  overflow-wrap: anywhere;
 }
 
 .cloudMetaRow {
@@ -280,12 +298,19 @@
   }
 
   .container {
-    width: min(100%, calc(100% - 40px));
+    padding-inline: 16px;
+    gap: 1.5rem;
   }
 
   .videoCardMedia,
   .imageCardMedia {
     min-height: 12rem;
+  }
+
+  .inlineActions {
+    display: grid;
+    justify-items: start;
+    gap: 0.85rem;
   }
 }
 

--- a/src/components/HomepageLinearFlow/styles.module.scss
+++ b/src/components/HomepageLinearFlow/styles.module.scss
@@ -26,8 +26,11 @@
 .container {
   position: relative;
   z-index: 1;
-  width: min(1200px, calc(100% - 48px));
+  width: 100%;
+  max-width: 1200px;
   margin: 0 auto;
+  padding-inline: 24px;
+  box-sizing: border-box;
   display: grid;
   grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
   gap: clamp(2rem, 4vw, 3.4rem);
@@ -58,6 +61,7 @@
   gap: 1.1rem;
   align-content: start;
   max-width: 34rem;
+  min-width: 0;
 }
 
 /* Monospace eyebrow - step badge */
@@ -181,6 +185,7 @@
   background: var(--oomol-bg-base);
   box-shadow: none;
   overflow: hidden;
+  min-width: 0;
 }
 
 .mediaPanel,
@@ -193,6 +198,7 @@
   min-height: inherit;
   display: grid;
   grid-template-rows: 1fr auto;
+  min-width: 0;
 }
 
 .videoCardInner,
@@ -260,6 +266,7 @@
   padding: 1rem 1.2rem 1.15rem;
   border-top: 1px solid var(--oomol-divider);
   background: var(--oomol-bg-base);
+  min-width: 0;
 }
 
 .videoCardTitle {
@@ -349,6 +356,7 @@
   overflow: hidden;
   background: var(--oomol-bg-base);
   margin-top: 0.4rem;
+  min-width: 0;
 }
 
 .cloudCard {
@@ -358,6 +366,7 @@
   background: transparent;
   box-shadow: none;
   transition: background-color 0.18s ease;
+  min-width: 0;
 
   &:nth-child(odd) {
     border-right: 1px solid var(--oomol-divider);
@@ -393,10 +402,13 @@
 }
 
 .ctaInner {
-  width: min(1200px, calc(100% - 48px));
+  width: 100%;
+  max-width: 1200px;
   margin: 0 auto;
   display: grid;
   gap: 1.1rem;
+  padding-inline: 24px;
+  box-sizing: border-box;
   padding: clamp(2.1rem, 4.2vw, 3rem);
   border-radius: 1.2rem;
   border: 1px solid var(--oomol-divider);
@@ -461,7 +473,7 @@
 @media (max-width: 768px) {
   .container,
   .ctaInner {
-    width: min(100%, calc(100% - 40px));
+    padding-inline: 16px;
   }
 
   .section {
@@ -498,9 +510,7 @@
   }
 
   .stepWatermark {
-    top: 1rem;
-    right: -1rem;
-    font-size: clamp(5rem, 24vw, 8rem);
+    display: none;
   }
 
   .inlineActions {
@@ -511,7 +521,7 @@
 @media (max-width: 480px) {
   .container,
   .ctaInner {
-    width: min(100%, calc(100% - 32px));
+    padding-inline: 12px;
   }
 
   .copyPanel {

--- a/src/theme/Navbar/index.tsx
+++ b/src/theme/Navbar/index.tsx
@@ -456,17 +456,25 @@ const NavbarComponent: React.FC<NavbarProps> = memo(() => {
               fallback={
                 <Button size="sm" className={styles.loginButton}>
                   <i className="i-lucide-log-in" />
-                  {translate({ message: "Theme.Navbar.login" })}
+                  <span className={styles.loginButtonLabel}>
+                    {translate({ message: "Theme.Navbar.login" })}
+                  </span>
                 </Button>
               }
             >
               {() => {
                 const signedIn = isSignedIn();
+                const buttonLabel = translate({
+                  message: signedIn
+                    ? "Theme.Navbar.console"
+                    : "Theme.Navbar.login",
+                });
                 return (
                   <Button
                     size="sm"
                     className={styles.loginButton}
                     onClick={() => handleSignin()}
+                    aria-label={buttonLabel}
                   >
                     <i
                       className={
@@ -475,11 +483,9 @@ const NavbarComponent: React.FC<NavbarProps> = memo(() => {
                           : "i-lucide-log-in"
                       }
                     />
-                    {translate({
-                      message: signedIn
-                        ? "Theme.Navbar.console"
-                        : "Theme.Navbar.login",
-                    })}
+                    <span className={styles.loginButtonLabel}>
+                      {buttonLabel}
+                    </span>
                   </Button>
                 );
               }}

--- a/src/theme/Navbar/styles.module.scss
+++ b/src/theme/Navbar/styles.module.scss
@@ -68,6 +68,10 @@
   }
 }
 
+.loginButtonLabel {
+  display: inline;
+}
+
 .actions {
   display: flex;
   align-items: center;
@@ -653,13 +657,23 @@
 
 @media (max-width: 430px) {
   .loginButton {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    width: 42px;
     min-width: 42px;
-    padding-inline: 0.8rem;
-    font-size: 0;
+    height: 42px;
+    padding: 0;
+    flex-shrink: 0;
   }
 
   .loginButton i {
     margin: 0;
     font-size: var(--oomol-body-base);
+  }
+
+  .loginButtonLabel {
+    display: none;
   }
 }


### PR DESCRIPTION
## What changed
- tightened the mobile layout behavior for the homepage Cloud linear-flow section so text blocks, cards, and media panels can shrink without overflowing the viewport
- updated the homepage linear-flow section to use safer container sizing on small screens and hide the oversized step watermark on mobile
- changed the mobile navbar console/login button into a true icon button so the icon stays visually centered while the button remains visible on small screens
- kept the accessible button label through `aria-label` while hiding the text label only on narrow mobile widths

## Why
The homepage looked different between a narrowed desktop window and an actual iPhone view. The mobile layout still had unstable spacing and overflow-sensitive behavior, and the navbar action button icon was visually off-center when the text label collapsed.

## User impact
- mobile homepage sections now behave more predictably on narrow screens
- the top-right mobile console/login button remains visible and its icon is centered
- the mobile view is closer to the cleaner narrow-layout presentation the user expected

## Root cause
The affected sections relied on width calculations and layout behavior that were more fragile on mobile browsers, and the navbar button was still styled like a text button even when reduced to an icon-only presentation.

## Validation
- ran `npm run build`
- verified both `build/` and `build/zh-CN/` completed successfully