### PR TITLE
fix mobile linear flow clipping

### DIFF
--- a/src/components/CloudPageLinearFlow/styles.module.scss
+++ b/src/components/CloudPageLinearFlow/styles.module.scss
@@ -29,7 +29,7 @@
   padding-inline: 24px;
   box-sizing: border-box;
   display: grid;
-  grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
+  grid-template-columns: 1fr;
   gap: clamp(2rem, 4vw, 3.4rem);
   align-items: start;
 }
@@ -278,9 +278,19 @@
   color: var(--oomol-text-tertiary);
 }
 
+@media (min-width: 997px) {
+  .container {
+    grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
+  }
+}
+
 /* ── Tablet ── */
 
 @media (max-width: 996px) {
+  .section {
+    overflow: visible;
+  }
+
   .container {
     grid-template-columns: 1fr;
   }

--- a/src/components/HomepageLinearFlow/styles.module.scss
+++ b/src/components/HomepageLinearFlow/styles.module.scss
@@ -32,7 +32,7 @@
   padding-inline: 24px;
   box-sizing: border-box;
   display: grid;
-  grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
+  grid-template-columns: 1fr;
   gap: clamp(2rem, 4vw, 3.4rem);
   align-items: start;
 }
@@ -349,7 +349,7 @@
 /* Cloud cards - nested mini cards - hairline stack */
 .cloudCardStack {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: 0;
   border: 1px solid var(--oomol-divider);
   border-radius: 12px;
@@ -368,15 +368,15 @@
   transition: background-color 0.18s ease;
   min-width: 0;
 
-  &:nth-child(odd) {
-    border-right: 1px solid var(--oomol-divider);
-  }
-
   &:hover {
     transform: none;
     border-color: var(--oomol-divider);
     box-shadow: none;
     background: var(--oomol-bg-spotlight);
+  }
+
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--oomol-divider);
   }
 }
 
@@ -437,34 +437,41 @@
   line-height: 1.06;
 }
 
-/* ── Tablet ── */
-
-@media (max-width: 996px) {
+@media (min-width: 997px) {
   .container {
-    grid-template-columns: 1fr;
-  }
-
-  .cliSection .container,
-  .cloudSection .container {
-    grid-template-columns: 1fr;
+    grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
   }
 
   .cloudCardStack {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .cloudCard {
+    &:not(:last-child) {
+      border-bottom: 0;
+    }
   }
 
   .cloudCard:nth-child(odd) {
-    border-right: 0;
-  }
-
-  .cloudCard:not(:last-child) {
-    border-bottom: 1px solid var(--oomol-divider);
+    border-right: 1px solid var(--oomol-divider);
   }
 
   .stepWatermark {
-    top: 1rem;
-    right: 2vw;
-    font-size: clamp(6rem, 18vw, 12rem);
+    top: clamp(2rem, 5vw, 4rem);
+    right: 4vw;
+    font-size: clamp(8rem, 22vw, 18rem);
+  }
+}
+
+/* ── Tablet ── */
+
+@media (max-width: 996px) {
+  .section {
+    overflow: visible;
+  }
+
+  .stepWatermark {
+    display: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- switch homepage and cloud linear-flow containers to a mobile-first single-column layout and enable split layout only on desktop breakpoints
- adjust cloud card stacking and separators so small viewports keep content within bounds
- add a lightweight mobile/tablet overflow guard to prevent real-device right-edge clipping regressions

## Test plan
- [x] Run `npx prettier --check src/components/HomepageLinearFlow/styles.module.scss src/components/CloudPageLinearFlow/styles.module.scss`
- [ ] Verify `/` linear-flow Studio/Cloud sections on a real phone viewport
- [ ] Verify `/cloud` linear-flow section on a real phone viewport

Made with [Cursor](https://cursor.com)