### PR TITLE
[codex] Simplify mobile layouts for homepage and footer

### DIFF
--- a/i18n/zh-CN/docusaurus-plugin-content-pages/terms/index.tsx
+++ b/i18n/zh-CN/docusaurus-plugin-content-pages/terms/index.tsx
@@ -17,10 +17,7 @@ export default function Index() {
     <Layout>
       <Head>
         <title>使用条款 - OOMOL</title>
-        <meta
-          name="description"
-          content="查看 OOMOL 的使用条款和服务条件。"
-        />
+        <meta name="description" content="查看 OOMOL 的使用条款和服务条件。" />
       </Head>
       <MDXProvider components={components}>
         <div className={styles.container}>

--- a/sidebars.js
+++ b/sidebars.js
@@ -21,10 +21,7 @@ const sidebars = {
       label: "oo-cli",
       collapsible: true,
       collapsed: true,
-      items: [
-        "cloud-services/cli",
-        "cloud-services/cli-command-reference",
-      ],
+      items: ["cloud-services/cli", "cloud-services/cli-command-reference"],
     },
     {
       type: "category",

--- a/src/components/CliPageLinearFlow/index.tsx
+++ b/src/components/CliPageLinearFlow/index.tsx
@@ -84,8 +84,7 @@ const zhCopy: Copy = {
       },
       {
         index: "03",
-        command:
-          "oo cloud-task wait <taskId>\noo cloud-task result <taskId>",
+        command: "oo cloud-task wait <taskId>\noo cloud-task result <taskId>",
         title: "收尾：等状态、取结果",
         text: "CLI 会等待状态、读日志，需要时用 result 取回结构化输出，Agent 再接下一步。",
       },
@@ -225,8 +224,7 @@ const enCopy: Copy = {
       },
       {
         index: "03",
-        command:
-          "oo cloud-task wait <taskId>\noo cloud-task result <taskId>",
+        command: "oo cloud-task wait <taskId>\noo cloud-task result <taskId>",
         title: "Finish: wait, then fetch the result",
         text: "The CLI waits for status changes and logs. Use result when you need structured output for the next step.",
       },

--- a/src/components/CloudPageDeveloperBenefits/styles.module.scss
+++ b/src/components/CloudPageDeveloperBenefits/styles.module.scss
@@ -1,6 +1,5 @@
 .section {
   padding: clamp(5rem, 10vw, 8rem) 0;
-  position: relative;
   background: var(--oomol-bg-base);
   border-bottom: 1px solid var(--oomol-divider);
 }
@@ -8,144 +7,119 @@
 .container {
   width: min(1200px, calc(100% - 48px));
   margin: 0 auto;
-  padding: 0;
   display: grid;
-  grid-template-columns: minmax(0, 0.74fr) minmax(0, 1.26fr);
-  gap: clamp(2rem, 4.4vw, 3.6rem);
-  align-items: start;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 .header {
   display: grid;
   gap: 0.9rem;
-  text-align: left;
-  padding-top: 0.25rem;
-  max-width: 30rem;
+  max-width: 48rem;
 }
 
-/* Monospace eyebrow — Vercel 一致风格 */
 .badge,
 .eyebrow {
   display: inline-flex;
   width: fit-content;
   align-items: center;
-  padding: 0;
-  border: 0;
-  background: transparent;
   font-family: var(--oomol-font-mono);
   font-size: var(--oomol-body-mono);
   font-weight: 500;
   letter-spacing: 0.02em;
-  text-transform: none;
   color: var(--oomol-primary);
-
-  &::before {
-    content: "";
-    display: inline-block;
-    width: 6px;
-    height: 6px;
-    margin-right: 0.6rem;
-    border-radius: 999px;
-    background: var(--oomol-primary);
-  }
 }
 
-.tag {
-  display: inline-flex;
-  width: fit-content;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.2rem 0.55rem;
-  border-radius: 6px;
-  font-family: var(--oomol-font-mono);
-  font-size: var(--oomol-font-size-xs);
-  font-weight: 500;
-  letter-spacing: 0.01em;
-  color: var(--oomol-text-tertiary);
-  background: var(--oomol-bg-container);
-  border: 1px solid var(--oomol-divider);
+.badge::before,
+.eyebrow::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  margin-right: 0.6rem;
+  border-radius: 999px;
+  background: var(--oomol-primary);
 }
 
 .title {
   margin: 0;
-  max-width: 14ch;
+  max-width: 18ch;
   font-family: var(--oomol-font-display);
   font-size: var(--oomol-display-hero);
-  line-height: 1.06;
+  line-height: 1.08;
   letter-spacing: var(--oomol-tracking-display);
   font-weight: 600;
   color: var(--oomol-text-primary);
   text-wrap: balance;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .subtitle {
   margin: 0;
-  max-width: 32rem;
+  max-width: 38rem;
   font-size: var(--oomol-body-lead);
   line-height: var(--oomol-line-height-relaxed);
   letter-spacing: var(--oomol-tracking-body);
   color: var(--oomol-text-secondary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0;
-  border: 1px solid var(--oomol-divider);
-  border-radius: 14px;
-  overflow: hidden;
-  background: var(--oomol-bg-base);
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
 }
 
 .card {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  min-height: 100%;
-  padding: 1.6rem 1.6rem 1.8rem;
-  border: 0;
-  border-radius: 0;
-  background: transparent;
-  box-shadow: none;
-  position: relative;
-  overflow: hidden;
-
-  &:nth-child(odd) {
-    border-right: 1px solid var(--oomol-divider);
-  }
-
-  &::before {
-    content: none;
-  }
+  gap: 0.9rem;
+  min-width: 0;
+  padding: 1.4rem 1.35rem 1.5rem;
+  border: 1px solid var(--oomol-divider);
+  border-radius: 14px;
+  background: var(--oomol-bg-base);
 }
 
-.modelCard::before,
-.cloudCard::before {
-  content: none;
+.modelCard,
+.cloudCard {
+  min-width: 0;
 }
 
 .cardTop {
   display: flex;
   justify-content: space-between;
-  gap: 1rem;
   align-items: flex-start;
-  padding-bottom: 0.25rem;
+  gap: 1rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 0.7rem;
+  border: 1px solid var(--oomol-divider);
+  border-radius: 999px;
+  background: var(--oomol-bg-container);
+  font-family: var(--oomol-font-mono);
+  font-size: var(--oomol-font-size-xs);
+  font-weight: 500;
+  color: var(--oomol-text-secondary);
 }
 
 .valueBox {
   display: grid;
-  gap: 0.45rem;
-  padding: 0.25rem 0 0.9rem;
+  gap: 0.35rem;
+  padding: 0.1rem 0 0.85rem;
   border-bottom: 1px solid var(--oomol-divider);
 }
 
 .value {
   margin: 0;
   font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-hero);
-  line-height: 1.06;
-  letter-spacing: var(--oomol-tracking-display);
-  font-weight: 500;
+  font-size: var(--oomol-display-section);
+  line-height: 1.08;
+  font-weight: 600;
   color: var(--oomol-text-primary);
   font-feature-settings: "tnum" 1;
 }
@@ -153,7 +127,7 @@
 .valueCaption {
   margin: 0;
   font-size: var(--oomol-body-mono);
-  line-height: 1.5;
+  line-height: 1.45;
   color: var(--oomol-text-tertiary);
 }
 
@@ -162,8 +136,9 @@
   font-size: var(--oomol-body-lead);
   line-height: 1.32;
   font-weight: 600;
-  letter-spacing: -0.012em;
   color: var(--oomol-text-primary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .cardDescription,
@@ -172,14 +147,12 @@
   font-size: var(--oomol-body-base);
   line-height: 1.6;
   color: var(--oomol-text-secondary);
-}
-
-.cardDescription {
-  max-width: 42ch;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .cardNote {
-  padding-left: 0.8rem;
+  padding-left: 0.75rem;
   border-left: 1px solid var(--oomol-divider);
   color: var(--oomol-text-tertiary);
   font-size: var(--oomol-body-sm);
@@ -187,94 +160,16 @@
 
 .cardFooter {
   margin-top: auto;
-  padding-top: 0.4rem;
+  padding-top: 0.25rem;
 }
 
 .cta {
   width: fit-content;
 }
 
-[data-theme="dark"] {
+@media (min-width: 997px) {
   .grid {
-    background: var(--oomol-bg-base);
-    border-color: var(--oomol-border-subtle);
-  }
-
-  .card:nth-child(odd) {
-    border-right-color: var(--oomol-border-subtle);
-  }
-
-  .tag {
-    background: var(--oomol-bg-elevated);
-    border-color: var(--oomol-border-default);
-  }
-
-  .cardNote {
-    border-left-color: var(--oomol-border-default);
-  }
-
-  .valueBox {
-    border-bottom-color: var(--oomol-border-subtle);
-  }
-}
-
-:global(html[lang="en"]) .container {
-  grid-template-columns: minmax(0, 0.74fr) minmax(0, 1.26fr);
-  gap: clamp(2rem, 4.4vw, 3.6rem);
-}
-
-:global(html[lang="en"]) .header {
-  max-width: 36rem;
-}
-
-:global(html[lang="en"]) .title {
-  max-width: 16ch;
-  font-size: var(--oomol-display-hero);
-  line-height: 1.06;
-}
-
-:global(html[lang="en"]) .subtitle {
-  max-width: 38rem;
-}
-
-:global(html[lang="en"]) .cardTitle {
-  max-width: 22ch;
-  font-size: var(--oomol-body-lead);
-  line-height: 1.34;
-}
-
-:global(html[lang="en"]) .cardDescription {
-  max-width: 44ch;
-  line-height: 1.62;
-}
-
-@media (max-width: 996px) {
-  .container {
-    grid-template-columns: 1fr;
-  }
-
-  :global(html[lang="en"]) .container {
-    grid-template-columns: 1fr;
-  }
-
-  .header {
-    max-width: 100%;
-  }
-
-  .title {
-    max-width: 100%;
-  }
-
-  .grid {
-    grid-template-columns: 1fr;
-  }
-
-  .card:nth-child(odd) {
-    border-right: 0;
-  }
-
-  .card:not(:last-child) {
-    border-bottom: 1px solid var(--oomol-divider);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -285,59 +180,56 @@
 
   .container {
     width: min(100%, calc(100% - 40px));
-    padding: 0;
   }
 
   .title {
     max-width: 100%;
-    font-size: var(--oomol-display-hero);
-    line-height: 1.08;
-    letter-spacing: var(--oomol-tracking-display);
-    text-wrap: pretty;
-  }
-
-  .value {
-    font-size: var(--oomol-display-hero);
-    line-height: 1.06;
-    letter-spacing: var(--oomol-tracking-display);
+    font-size: var(--oomol-display-section);
   }
 
   .subtitle {
     font-size: var(--oomol-body-base);
-    line-height: 1.62;
-  }
-
-  .card {
-    gap: 0.85rem;
-    padding: 1.3rem 1.25rem 1.4rem;
-  }
-
-  .cardTop {
-    gap: 0.65rem;
-  }
-
-  .valueBox {
-    gap: 0.45rem;
-    padding-bottom: 0.75rem;
-  }
-
-  .cardTitle {
-    font-size: var(--oomol-body-lead);
-    line-height: 1.3;
-  }
-
-  .cardDescription,
-  .cardNote {
-    font-size: var(--oomol-body-base);
     line-height: 1.6;
   }
 
-  .cardNote {
-    padding-left: 0.7rem;
+  .card {
+    padding: 1.25rem 1.15rem 1.3rem;
   }
 
-  .valueCaption {
-    font-size: var(--oomol-body-mono);
-    line-height: 1.45;
+  .cardTop {
+    flex-wrap: wrap;
+    gap: 0.6rem;
   }
+}
+
+@media (max-width: 480px) {
+  .container {
+    width: min(100%, calc(100% - 32px));
+  }
+
+  .title {
+    font-size: var(--oomol-display-card);
+    line-height: 1.14;
+  }
+}
+
+[data-theme="dark"] {
+  .card {
+    border-color: var(--oomol-border-subtle);
+    background: var(--oomol-bg-elevated);
+  }
+
+  .tag {
+    background: var(--oomol-bg-elevated);
+    border-color: var(--oomol-border-default);
+  }
+
+  .valueBox,
+  .cardNote {
+    border-color: var(--oomol-border-default);
+  }
+}
+
+:global(html[lang="en"]) .title {
+  max-width: 22ch;
 }

--- a/src/components/CloudPageLinearFlow/index.tsx
+++ b/src/components/CloudPageLinearFlow/index.tsx
@@ -158,7 +158,8 @@ const enCopy: Copy = {
       "Once the tool is validated, Cloud takes over delivery and keeps hosted runtime, runtime settings, secrets, and access control in one place. By default, the tool is still delivered mainly through oo-cli.",
     cards: [
       {
-        title: "Deliver it mainly through oo-cli while keeping the same implementation",
+        title:
+          "Deliver it mainly through oo-cli while keeping the same implementation",
         text: "Once the tool is delivered, agents still use it mainly through oo-cli instead of through a separate service layer built around it.",
       },
       {

--- a/src/components/CloudPageLinearFlow/styles.module.scss
+++ b/src/components/CloudPageLinearFlow/styles.module.scss
@@ -4,12 +4,9 @@
 }
 
 .section {
-  position: relative;
-  width: 100%;
   padding: clamp(5rem, 10vw, 8rem) 0;
   background: var(--oomol-bg-base);
   border-bottom: 1px solid var(--oomol-divider);
-  overflow: hidden;
 }
 
 .cloudSection {
@@ -21,28 +18,22 @@
 }
 
 .container {
-  position: relative;
-  z-index: 1;
-  width: 100%;
-  max-width: 1200px;
+  width: min(1200px, calc(100% - 48px));
   margin: 0 auto;
-  padding-inline: 24px;
-  box-sizing: border-box;
   display: grid;
-  grid-template-columns: 1fr;
-  gap: clamp(2rem, 4vw, 3.4rem);
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(1.5rem, 3vw, 2.5rem);
   align-items: start;
 }
 
 .copyPanel {
   display: grid;
-  gap: 1.1rem;
+  gap: 1rem;
   align-content: start;
   max-width: 34rem;
   min-width: 0;
 }
 
-/* Mono eyebrow */
 .eyebrow {
   display: inline-flex;
   align-items: center;
@@ -50,32 +41,31 @@
   font-family: var(--oomol-font-mono);
   font-size: var(--oomol-body-mono);
   font-weight: 500;
-  letter-spacing: var(--oomol-tracking-mono);
-  text-transform: none;
+  letter-spacing: 0.02em;
   color: var(--oomol-primary);
+}
 
-  &::before {
-    content: "";
-    display: inline-block;
-    width: 6px;
-    height: 6px;
-    margin-right: 0.55rem;
-    border-radius: 999px;
-    background: var(--oomol-primary);
-  }
+.eyebrow::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  margin-right: 0.55rem;
+  border-radius: 999px;
+  background: var(--oomol-primary);
 }
 
 .sectionTitle {
   margin: 0;
-  max-width: 100%;
+  max-width: 18ch;
   font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-section);
-  line-height: 1.06;
-  letter-spacing: var(--oomol-tracking-section);
+  font-size: var(--oomol-display-hero);
+  line-height: 1.08;
+  letter-spacing: var(--oomol-tracking-display);
   font-weight: 600;
   color: var(--oomol-text-primary);
   text-wrap: balance;
   overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .sectionDescription {
@@ -86,155 +76,120 @@
   letter-spacing: var(--oomol-tracking-body);
   color: var(--oomol-text-secondary);
   overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
-/* Inline action links */
 .inlineActions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 1.4rem;
-  padding-top: 0.6rem;
+  gap: 0.8rem 1.2rem;
+  padding-top: 0.2rem;
 }
 
 .primaryLink,
 .secondaryLink {
   display: inline-flex;
   align-items: center;
-  max-width: 100%;
-  gap: 0.3rem;
+  gap: 0.35rem;
+  min-width: 0;
   font-size: var(--oomol-body-base);
   font-weight: 500;
   color: var(--oomol-text-primary);
   text-decoration: none;
-  transition: color 0.15s ease;
+  white-space: normal;
   overflow-wrap: anywhere;
+}
 
-  &::after {
-    content: "→";
-    flex: 0 0 auto;
-    color: var(--oomol-text-tertiary);
-    transition: transform 0.15s ease;
-  }
+.primaryLink::after,
+.secondaryLink::after {
+  content: "→";
+  flex: none;
+  color: var(--oomol-text-tertiary);
+  transition: transform 0.15s ease;
+}
 
-  &:hover {
-    text-decoration: none;
-    color: var(--oomol-primary);
+.primaryLink:hover,
+.secondaryLink:hover {
+  text-decoration: none;
+}
 
-    &::after {
-      transform: translateX(3px);
-      color: var(--oomol-primary);
-    }
-  }
+.primaryLink:hover::after,
+.secondaryLink:hover::after {
+  transform: translateX(2px);
 }
 
 .secondaryLink {
   color: var(--oomol-text-secondary);
-
-  &:hover {
-    color: var(--oomol-text-primary);
-
-    &::after {
-      color: var(--oomol-text-primary);
-    }
-  }
 }
 
-/* Nested cards in copy panel — hairline grid stack (3 cards) */
 .cloudCardStack {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 0;
-  border: 1px solid var(--oomol-divider);
-  border-radius: 12px;
-  overflow: hidden;
-  background: var(--oomol-bg-base);
-  margin-top: 0.4rem;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.75rem;
+  margin-top: 0.2rem;
   min-width: 0;
 }
 
 .cloudCard {
-  padding: 1rem 1.15rem 1.1rem;
-  border-radius: 0;
-  border: 0;
-  background: transparent;
-  box-shadow: none !important;
-  transition: background-color 0.18s ease;
   min-width: 0;
-
-  &:not(:last-child) {
-    border-bottom: 1px solid var(--oomol-divider);
-  }
-
-  &:hover {
-    background: var(--oomol-bg-container);
-  }
+  padding: 1rem 1.05rem;
+  border: 1px solid var(--oomol-divider);
+  border-radius: 12px;
+  background: var(--oomol-bg-base);
 }
 
 .cloudTitle {
   margin: 0;
   font-size: var(--oomol-body-base);
-  line-height: 1.32;
+  line-height: 1.34;
   font-weight: 600;
-  letter-spacing: -0.01em;
   color: var(--oomol-text-primary);
   overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .cloudText {
-  margin: 0.4rem 0 0;
+  margin: 0.45rem 0 0;
   font-size: var(--oomol-body-sm);
   line-height: 1.58;
   color: var(--oomol-text-secondary);
   overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
-/* Media panel — hairline frame */
 .mediaPanel {
-  border-radius: 14px;
-  border: 1px solid var(--oomol-divider);
-  background: var(--oomol-bg-base);
-  box-shadow: none;
-  overflow: hidden;
-  min-height: clamp(20rem, 36vw, 30rem);
   min-width: 0;
+  border: 1px solid var(--oomol-divider);
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--oomol-bg-base);
 }
 
 .videoCard {
-  height: 100%;
-  min-height: inherit;
   display: grid;
-  grid-template-rows: 1fr auto;
   min-width: 0;
 }
 
 .videoCardMedia,
 .imageCardMedia {
-  position: relative;
-  display: grid;
-  place-items: center;
+  aspect-ratio: 16 / 10;
+  min-height: 0;
   background: var(--oomol-bg-spotlight);
-  min-height: 16rem;
 }
 
-.videoCardVideo {
-  width: 100%;
-  height: 100%;
-  min-height: inherit;
-  display: block;
-  object-fit: cover;
-}
-
+.videoCardVideo,
 .imageCardImage {
+  display: block;
   width: 100%;
   height: 100%;
-  min-height: inherit;
-  display: block;
   object-fit: cover;
 }
 
 .videoCardMeta {
-  padding: 1rem 1.2rem 1.15rem;
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1.1rem 1.15rem;
   border-top: 1px solid var(--oomol-divider);
   background: var(--oomol-bg-base);
   min-width: 0;
@@ -243,34 +198,36 @@
 .videoCardTitle {
   margin: 0;
   font-size: var(--oomol-body-base);
-  font-weight: 500;
   line-height: 1.35;
-  letter-spacing: -0.01em;
+  font-weight: 500;
   color: var(--oomol-text-primary);
   overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .videoCardNote {
-  margin: 0.35rem 0 0;
+  margin: 0;
   font-size: var(--oomol-body-sm);
   line-height: 1.56;
   color: var(--oomol-text-tertiary);
   overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .cloudMetaRow {
   display: flex;
   flex-wrap: wrap;
   gap: 0.35rem;
-  padding-top: 0.6rem;
+  padding-top: 0.45rem;
 }
 
 .cloudMetaPill {
   display: inline-flex;
   align-items: center;
-  padding: 0.1rem 0.45rem;
-  border-radius: 5px;
+  min-height: 24px;
+  padding: 0 0.55rem;
   border: 1px solid var(--oomol-divider);
+  border-radius: 999px;
   background: var(--oomol-bg-container);
   font-family: var(--oomol-font-mono);
   font-size: var(--oomol-font-size-xs);
@@ -280,27 +237,13 @@
 
 @media (min-width: 997px) {
   .container {
-    grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
+    grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+  }
+
+  .cloudCardStack {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
-
-/* ── Tablet ── */
-
-@media (max-width: 996px) {
-  .section {
-    overflow: visible;
-  }
-
-  .container {
-    grid-template-columns: 1fr;
-  }
-
-  .copyPanel {
-    max-width: 100%;
-  }
-}
-
-/* ── Mobile ── */
 
 @media (max-width: 768px) {
   .section {
@@ -308,55 +251,66 @@
   }
 
   .container {
-    padding-inline: 16px;
-    gap: 1.5rem;
+    width: min(100%, calc(100% - 40px));
+    gap: 1.25rem;
+  }
+
+  .copyPanel {
+    gap: 0.85rem;
+  }
+
+  .sectionTitle {
+    max-width: 100%;
+    font-size: var(--oomol-display-section);
+    line-height: 1.1;
+  }
+
+  .sectionDescription {
+    font-size: var(--oomol-body-base);
+    line-height: 1.6;
+  }
+
+  .inlineActions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.7rem;
+  }
+
+  .videoCardMeta {
+    padding: 0.9rem 1rem 1rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .container {
+    width: min(100%, calc(100% - 32px));
+  }
+
+  .sectionTitle {
+    font-size: var(--oomol-display-card);
+    line-height: 1.14;
   }
 
   .videoCardMedia,
   .imageCardMedia {
-    min-height: 12rem;
-  }
-
-  .inlineActions {
-    display: grid;
-    justify-items: start;
-    gap: 0.85rem;
+    aspect-ratio: 4 / 3;
   }
 }
-
-/* ── Dark mode ── */
 
 [data-theme="dark"] {
   .cliSection {
     background: var(--oomol-bg-container);
   }
 
-  .cloudCardStack {
-    background: var(--oomol-bg-base);
-    border-color: var(--oomol-border-subtle);
-  }
-
-  .cloudCard:not(:last-child) {
-    border-bottom-color: var(--oomol-border-subtle);
-  }
-
-  .cloudCard:hover {
-    background: var(--oomol-bg-elevated);
-  }
-
+  .cloudCard,
   .mediaPanel {
-    background: var(--oomol-bg-elevated);
     border-color: var(--oomol-border-subtle);
+    background: var(--oomol-bg-elevated);
   }
 
   .videoCardMeta {
-    background: var(--oomol-bg-elevated);
     border-top-color: var(--oomol-border-subtle);
-  }
-
-  .videoCardMedia,
-  .imageCardMedia {
-    background: var(--oomol-bg-spotlight);
+    background: var(--oomol-bg-elevated);
   }
 
   .cloudMetaPill {

--- a/src/components/CloudPagePainPoints/index.tsx
+++ b/src/components/CloudPagePainPoints/index.tsx
@@ -30,7 +30,10 @@ const zhCopy: Copy = {
       title: "不用再围着同一份实现补一套后台",
       description:
         "Cloud 承接交付、配置、权限和运行关系，让你不需要再单独做一个发布后台去包住同一份实现。",
-      points: ["主要沿 oo-cli 继续交付给 Agent", "不用再额外补一层用户入口和管理面"],
+      points: [
+        "主要沿 oo-cli 继续交付给 Agent",
+        "不用再额外补一层用户入口和管理面",
+      ],
     },
     {
       icon: "i-lucide-blocks",

--- a/src/components/CookieConsent/CookieConsentProvider.tsx
+++ b/src/components/CookieConsent/CookieConsentProvider.tsx
@@ -178,7 +178,9 @@ export function useCookieConsent(): CookieConsentContextValue {
   const ctx = useContext(CookieConsentContext);
 
   if (!ctx) {
-    throw new Error("useCookieConsent must be used within CookieConsentProvider");
+    throw new Error(
+      "useCookieConsent must be used within CookieConsentProvider"
+    );
   }
 
   return ctx;
@@ -389,10 +391,7 @@ const CookieConsentProviderInner: React.FC = () => {
         </div>
       ) : null}
 
-      <Dialog.Root
-        onOpenChange={setPreferencesOpen}
-        open={preferencesOpen}
-      >
+      <Dialog.Root onOpenChange={setPreferencesOpen} open={preferencesOpen}>
         <Dialog.Portal>
           <Dialog.Overlay
             className="fixed inset-0 bg-[var(--oomol-mask)] backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"

--- a/src/components/CookieConsent/cookieConsentStorage.ts
+++ b/src/components/CookieConsent/cookieConsentStorage.ts
@@ -72,13 +72,8 @@ function writeCookie(name: string, value: string, days: number) {
   document.cookie = parts.join("; ");
 }
 
-export function normalizeDetailedConsent(
-  raw: unknown
-): DetailedCookieConsent {
-  const safeStatus = (
-    status: unknown,
-    fallbackTs: string
-  ): ConsentStatus => {
+export function normalizeDetailedConsent(raw: unknown): DetailedCookieConsent {
+  const safeStatus = (status: unknown, fallbackTs: string): ConsentStatus => {
     if (
       status &&
       typeof status === "object" &&
@@ -144,8 +139,7 @@ export function migrateLegacyConsentCookie() {
       return;
     }
 
-    const hasStatisticsConsent =
-      parsedCookie.categories.includes("statistics");
+    const hasStatisticsConsent = parsedCookie.categories.includes("statistics");
     const timestamp =
       parsedCookie.lastConsentTimestamp ??
       parsedCookie.consentTimestamp ??
@@ -180,8 +174,8 @@ export function readStoredConsent(): DetailedCookieConsent | null {
     const parsed = JSON.parse(raw) as unknown;
     const normalized = normalizeDetailedConsent(parsed);
     const oldestTimestamp = Math.min(
-      ...Object.values(normalized).map(
-        status => new Date(status.timestamp).getTime()
+      ...Object.values(normalized).map(status =>
+        new Date(status.timestamp).getTime()
       )
     );
     const expirationTime =

--- a/src/components/HomepageBrandBreak/styles.module.scss
+++ b/src/components/HomepageBrandBreak/styles.module.scss
@@ -55,7 +55,9 @@
   border: 1px solid color-mix(in srgb, var(--oomol-bg-base) 18%, transparent);
   background: color-mix(in srgb, var(--oomol-bg-base) 8%, transparent);
   min-width: 9rem;
-  transition: border-color 0.2s ease, background-color 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease;
 
   &:hover {
     border-color: color-mix(in srgb, var(--oomol-bg-base) 26%, transparent);

--- a/src/components/HomepageCodexBlocks/styles.module.scss
+++ b/src/components/HomepageCodexBlocks/styles.module.scss
@@ -308,11 +308,7 @@
   }
 
   .videoGradient {
-    background: color-mix(
-      in srgb,
-      var(--oomol-bg-container) 88%,
-      black 12%
-    );
+    background: color-mix(in srgb, var(--oomol-bg-container) 88%, black 12%);
   }
 
   .videoTracks span {

--- a/src/components/HomepageCoreFeatures/styles.module.scss
+++ b/src/components/HomepageCoreFeatures/styles.module.scss
@@ -52,8 +52,8 @@
   background: var(--oomol-bg-elevated);
   box-shadow: none;
   animation: fadeInUp 0.65s ease-out both;
-  transition:
-    border-color var(--oomol-motion-duration-base) var(--oomol-motion-ease-standard);
+  transition: border-color var(--oomol-motion-duration-base)
+    var(--oomol-motion-ease-standard);
 
   &:hover {
     border-color: var(--oomol-border-strong);

--- a/src/components/HomepageGuiEntry/styles.module.scss
+++ b/src/components/HomepageGuiEntry/styles.module.scss
@@ -1,5 +1,4 @@
 .section {
-  width: 100%;
   padding: clamp(5rem, 10vw, 8rem) 0;
   background: var(--oomol-bg-base);
   border-bottom: 1px solid var(--oomol-divider);
@@ -12,57 +11,51 @@
 
 .card {
   display: grid;
-  grid-template-columns: minmax(0, 1.08fr) minmax(280px, 0.92fr);
-  gap: clamp(2rem, 4vw, 3.4rem);
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(1.5rem, 3vw, 2.5rem);
   align-items: center;
-  padding: 0;
-  border-radius: 0;
-  border: 0;
-  background: transparent;
-  box-shadow: none;
 }
 
 .copy {
   display: grid;
-  gap: 0.9rem;
+  gap: 1rem;
   align-content: start;
+  max-width: 34rem;
+  min-width: 0;
 }
 
 .badge {
   display: inline-flex;
   width: fit-content;
   align-items: center;
-  padding: 0;
-  border: 0;
-  background: transparent;
   font-family: var(--oomol-font-mono);
   font-size: var(--oomol-body-mono);
   font-weight: 500;
   letter-spacing: 0.02em;
-  text-transform: none;
   color: var(--oomol-primary);
+}
 
-  &::before {
-    content: "";
-    display: inline-block;
-    width: 6px;
-    height: 6px;
-    margin-right: 0.6rem;
-    border-radius: 999px;
-    background: var(--oomol-primary);
-  }
+.badge::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  margin-right: 0.6rem;
+  border-radius: 999px;
+  background: var(--oomol-primary);
 }
 
 .title {
   margin: 0;
-  font-family: var(--oomol-font-display);
   max-width: 22ch;
+  font-family: var(--oomol-font-display);
   font-size: var(--oomol-display-section);
   line-height: 1.08;
   letter-spacing: var(--oomol-tracking-section);
   font-weight: 600;
   color: var(--oomol-text-primary);
   text-wrap: balance;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .brandNoWrap {
@@ -76,33 +69,33 @@
   line-height: var(--oomol-line-height-relaxed);
   letter-spacing: var(--oomol-tracking-body);
   color: var(--oomol-text-secondary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .pointRow {
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
-  padding-top: 0.2rem;
 }
 
 .point {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 26px;
-  padding: 0 0.7rem;
-  border-radius: 6px;
+  min-height: 28px;
+  padding: 0 0.75rem;
+  border: 1px solid var(--oomol-divider);
+  border-radius: 999px;
+  background: var(--oomol-bg-container);
   font-family: var(--oomol-font-mono);
   font-size: var(--oomol-font-size-xs);
   font-weight: 500;
-  letter-spacing: 0.01em;
   color: var(--oomol-text-secondary);
-  background: var(--oomol-bg-container);
-  border: 1px solid var(--oomol-divider);
 }
 
 .actions {
-  padding-top: 0.4rem;
+  padding-top: 0.2rem;
 }
 
 .media {
@@ -111,33 +104,20 @@
 
 .mediaFrame {
   overflow: hidden;
-  border-radius: 14px;
   border: 1px solid var(--oomol-divider);
+  border-radius: 14px;
   background: var(--oomol-bg-spotlight);
-  box-shadow: none;
 }
 
 .mediaImage {
   display: block;
   width: 100%;
   height: auto;
-  opacity: 1;
 }
 
-:global([data-theme="dark"]) .mediaFrame {
-  border-color: var(--oomol-border-subtle);
-  background: var(--oomol-bg-spotlight);
-}
-
-:global([data-theme="dark"]) .point {
-  background: var(--oomol-bg-elevated);
-  border-color: var(--oomol-border-default);
-}
-
-@media (max-width: 900px) {
+@media (min-width: 997px) {
   .card {
-    grid-template-columns: 1fr;
-    gap: 2rem;
+    grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
   }
 }
 
@@ -148,11 +128,6 @@
 
   .container {
     width: min(100%, calc(100% - 40px));
-  }
-
-  .card {
-    gap: 1.6rem;
-    padding: 0;
   }
 
   .title {
@@ -167,7 +142,6 @@
 
   .actions {
     display: grid;
-    grid-template-columns: 1fr;
     width: 100%;
     max-width: 20rem;
   }
@@ -175,4 +149,25 @@
   .actions > * {
     width: 100%;
   }
+}
+
+@media (max-width: 480px) {
+  .container {
+    width: min(100%, calc(100% - 32px));
+  }
+
+  .title {
+    font-size: var(--oomol-display-card);
+    line-height: 1.14;
+  }
+}
+
+:global([data-theme="dark"]) .mediaFrame {
+  border-color: var(--oomol-border-subtle);
+  background: var(--oomol-bg-spotlight);
+}
+
+:global([data-theme="dark"]) .point {
+  background: var(--oomol-bg-elevated);
+  border-color: var(--oomol-border-default);
 }

--- a/src/components/HomepageGuiEntry/styles.module.scss
+++ b/src/components/HomepageGuiEntry/styles.module.scss
@@ -55,7 +55,6 @@
   color: var(--oomol-text-primary);
   text-wrap: balance;
   overflow-wrap: anywhere;
-  word-break: break-word;
 }
 
 .brandNoWrap {
@@ -70,7 +69,6 @@
   letter-spacing: var(--oomol-tracking-body);
   color: var(--oomol-text-secondary);
   overflow-wrap: anywhere;
-  word-break: break-word;
 }
 
 .pointRow {

--- a/src/components/HomepageLinearFlow/styles.module.scss
+++ b/src/components/HomepageLinearFlow/styles.module.scss
@@ -4,272 +4,171 @@
 }
 
 .section {
-  position: relative;
-  width: 100%;
   padding: clamp(5rem, 10vw, 8rem) 0;
   background: var(--oomol-bg-base);
   border-bottom: 1px solid var(--oomol-divider);
-  overflow: hidden;
 }
 
 .sectionTint,
-.cloudSection,
 .cliSection {
   background: var(--oomol-bg-base);
 }
 
-/* 浅色底纹变化：奇数段 base，偶数段稍带 container，制造 Vercel 式的段落区隔 */
 .cloudSection {
   background: var(--oomol-bg-container);
 }
 
-.container {
-  position: relative;
-  z-index: 1;
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding-inline: 24px;
-  box-sizing: border-box;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: clamp(2rem, 4vw, 3.4rem);
-  align-items: start;
+.stepWatermark {
+  display: none;
 }
 
-/* 巨大空心 step 序号水印 */
-.stepWatermark {
-  position: absolute;
-  top: clamp(2rem, 5vw, 4rem);
-  right: 4vw;
-  z-index: 0;
-  font-family: var(--oomol-font-display);
-  font-size: clamp(8rem, 22vw, 18rem);
-  line-height: 0.9;
-  font-weight: 600;
-  letter-spacing: -0.05em;
-  color: transparent;
-  -webkit-text-stroke: 1px var(--oomol-border-default);
-  opacity: 0.7;
-  pointer-events: none;
-  user-select: none;
-  font-feature-settings: "tnum" 1;
+.container {
+  width: min(1200px, calc(100% - 48px));
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  align-items: start;
 }
 
 .copyPanel {
   display: grid;
-  gap: 1.1rem;
+  gap: 1rem;
   align-content: start;
   max-width: 34rem;
   min-width: 0;
 }
 
-/* Monospace eyebrow - step badge */
 .eyebrow {
   display: inline-flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.7rem;
-  padding: 0;
-  border: 0;
-  background: transparent;
+  gap: 0.65rem;
+  width: fit-content;
   font-family: var(--oomol-font-mono);
   font-size: var(--oomol-body-mono);
   font-weight: 500;
   letter-spacing: 0.02em;
-  text-transform: none;
   color: var(--oomol-primary);
-  box-shadow: none;
-  min-height: auto;
-  border-radius: 0;
-  width: fit-content;
 }
 
 .eyebrowNumber {
-  color: var(--oomol-primary);
   font-weight: 600;
 }
 
 .eyebrowDivider {
-  display: inline-block;
-  width: 20px;
+  width: 18px;
   height: 1px;
   background: var(--oomol-border-strong);
-  flex-shrink: 0;
+  flex: none;
 }
 
 .eyebrowLabel {
   color: var(--oomol-text-secondary);
-  font-weight: 500;
   overflow-wrap: anywhere;
 }
 
-/* Section titles */
-.sectionTitle,
-.ctaTitle {
+.sectionTitle {
   margin: 0;
-  max-width: 100%;
+  max-width: 18ch;
   font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-section);
-  line-height: 1.06;
-  letter-spacing: var(--oomol-tracking-section);
+  font-size: var(--oomol-display-hero);
+  line-height: 1.08;
+  letter-spacing: var(--oomol-tracking-display);
   font-weight: 600;
-  text-wrap: pretty;
   color: var(--oomol-text-primary);
+  text-wrap: balance;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
-.sectionDescription,
-.ctaDescription {
+.sectionDescription {
   margin: 0;
   max-width: 36rem;
   font-size: var(--oomol-body-lead);
   line-height: var(--oomol-line-height-relaxed);
   letter-spacing: var(--oomol-tracking-body);
   color: var(--oomol-text-secondary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
-/* Inline actions - 扁平 text link 风格 */
 .inlineActions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 1.4rem;
-  padding-top: 0.6rem;
+  gap: 0.8rem 1.2rem;
+  padding-top: 0.2rem;
 }
 
 .primaryLink,
 .secondaryLink {
   display: inline-flex;
   align-items: center;
-  max-width: 100%;
-  gap: 0.3rem;
+  gap: 0.35rem;
+  min-width: 0;
   font-size: var(--oomol-body-base);
   font-weight: 500;
   color: var(--oomol-text-primary);
   text-decoration: none;
-  letter-spacing: -0.003em;
-  transition: color 0.15s ease;
-  overflow-wrap: anywhere;
   white-space: normal;
+  overflow-wrap: anywhere;
+}
 
-  &::after {
-    content: "→";
-    flex: 0 0 auto;
-    transition: transform 0.15s ease;
-    color: var(--oomol-text-tertiary);
-  }
+.primaryLink::after,
+.secondaryLink::after {
+  content: "→";
+  flex: none;
+  color: var(--oomol-text-tertiary);
+  transition: transform 0.15s ease;
+}
 
-  &:hover {
-    text-decoration: none;
-    color: var(--oomol-primary);
+.primaryLink:hover,
+.secondaryLink:hover {
+  text-decoration: none;
+}
 
-    &::after {
-      transform: translateX(3px);
-      color: var(--oomol-primary);
-    }
-  }
+.primaryLink:hover::after,
+.secondaryLink:hover::after {
+  transform: translateX(2px);
 }
 
 .secondaryLink {
   color: var(--oomol-text-secondary);
-
-  &:hover {
-    color: var(--oomol-text-primary);
-
-    &::after {
-      color: var(--oomol-text-primary);
-    }
-  }
 }
 
-/* Media panel + video card — 全部 hairline，无阴影光 */
-.terminalPanel,
-.mediaPanel,
-.agentMediaCard {
-  border-radius: 14px;
-  border: 1px solid var(--oomol-divider);
-  background: var(--oomol-bg-base);
-  box-shadow: none;
-  overflow: hidden;
+.mediaPanel {
   min-width: 0;
-}
-
-.mediaPanel,
-.agentMediaCard {
-  min-height: clamp(20rem, 36vw, 30rem);
+  border: 1px solid var(--oomol-divider);
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--oomol-bg-base);
 }
 
 .videoCard {
-  height: 100%;
-  min-height: inherit;
   display: grid;
-  grid-template-rows: 1fr auto;
   min-width: 0;
 }
 
-.videoCardInner,
-.videoCardMedia {
-  position: relative;
-  display: grid;
-  place-items: center;
-  background: var(--oomol-bg-spotlight);
-  min-height: 16rem;
-  contain: layout paint;
-}
-
-.videoCardVideo {
-  width: 100%;
-  height: 100%;
-  min-height: inherit;
-  display: block;
-  object-fit: cover;
-  background: transparent;
-}
-
+.videoCardMedia,
 .imageCardMedia {
-  min-height: 16rem;
+  aspect-ratio: 16 / 10;
+  min-height: 0;
   background: var(--oomol-bg-spotlight);
-  display: grid;
-  place-items: center;
 }
 
+.videoCardVideo,
 .imageCardImage {
+  display: block;
   width: 100%;
   height: 100%;
-  min-height: inherit;
-  display: block;
   object-fit: cover;
-}
-
-.videoCardPlay {
-  width: 4rem;
-  height: 4rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.96);
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  box-shadow: none;
-  cursor: pointer;
-  transition: transform 0.18s ease;
-
-  &:hover {
-    transform: scale(1.02);
-  }
-}
-
-.videoCardTriangle {
-  width: 0;
-  height: 0;
-  margin-left: 0.2rem;
-  border-top: 0.7rem solid transparent;
-  border-bottom: 0.7rem solid transparent;
-  border-left: 1.1rem solid var(--oomol-text-primary);
 }
 
 .videoCardMeta {
-  padding: 1rem 1.2rem 1.15rem;
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 1.1rem 1.15rem;
   border-top: 1px solid var(--oomol-divider);
   background: var(--oomol-bg-base);
   min-width: 0;
@@ -278,297 +177,128 @@
 .videoCardTitle {
   margin: 0;
   font-size: var(--oomol-body-base);
-  font-weight: 500;
   line-height: 1.35;
-  letter-spacing: -0.01em;
+  font-weight: 500;
   color: var(--oomol-text-primary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .videoCardNote {
-  margin: 0.35rem 0 0;
+  margin: 0;
   font-size: var(--oomol-body-sm);
   line-height: 1.56;
   color: var(--oomol-text-tertiary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
-/* Terminal panel (used elsewhere) */
-.terminalPanel {
-  display: grid;
-}
-
-.terminalChrome {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--oomol-divider);
-
-  span {
-    width: 0.55rem;
-    height: 0.55rem;
-    border-radius: 999px;
-    background: var(--oomol-border-strong);
-  }
-}
-
-.terminalBody {
-  display: grid;
-  gap: 0.8rem;
-  padding: 1rem 1.2rem 1.2rem;
-}
-
-.terminalLabel {
-  font-family: var(--oomol-font-mono);
-  font-size: var(--oomol-font-size-xs);
-  font-weight: 500;
-  letter-spacing: 0.06em;
-  text-transform: none;
-  color: var(--oomol-text-tertiary);
-}
-
-.commandBlock {
-  margin: 0;
-  padding: 0;
-  white-space: pre-wrap;
-  font-family: var(--oomol-font-mono);
-  font-size: var(--oomol-body-base);
-  line-height: 1.9;
-  color: var(--oomol-text-primary);
-}
-
-.commandLine {
-  display: block;
-}
-
-.commentLine {
-  display: block;
-  margin: 0 0 0.3rem;
-  font-size: var(--oomol-body-sm);
-  line-height: 1.5;
-  color: var(--oomol-text-tertiary);
-}
-
-.prompt {
-  color: var(--oomol-primary);
-}
-
-/* Cloud cards - nested mini cards - hairline stack */
 .cloudCardStack {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 0;
-  border: 1px solid var(--oomol-divider);
-  border-radius: 12px;
-  overflow: hidden;
-  background: var(--oomol-bg-base);
-  margin-top: 0.4rem;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 0.75rem;
+  margin-top: 0.2rem;
   min-width: 0;
 }
 
 .cloudCard {
-  padding: 1.1rem 1.15rem 1.2rem;
-  border-radius: 0;
-  border: 0;
-  background: transparent;
-  box-shadow: none;
-  transition: background-color 0.18s ease;
   min-width: 0;
-
-  &:hover {
-    transform: none;
-    border-color: var(--oomol-divider);
-    box-shadow: none;
-    background: var(--oomol-bg-spotlight);
-  }
-
-  &:not(:last-child) {
-    border-bottom: 1px solid var(--oomol-divider);
-  }
+  padding: 1rem 1.05rem;
+  border: 1px solid var(--oomol-divider);
+  border-radius: 12px;
+  background: var(--oomol-bg-base);
 }
 
 .cloudTitle {
   margin: 0;
   font-size: var(--oomol-body-base);
   line-height: 1.34;
-  letter-spacing: -0.01em;
   font-weight: 600;
   color: var(--oomol-text-primary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .cloudText {
-  margin: 0.5rem 0 0;
+  margin: 0.45rem 0 0;
   font-size: var(--oomol-body-sm);
   line-height: 1.58;
   color: var(--oomol-text-secondary);
-}
-
-/* CTA section - the SiteCta wrapper is separately styled */
-.ctaSection {
-  padding: clamp(4rem, 8vw, 5.8rem) 0 clamp(3rem, 6vw, 4.4rem);
-}
-
-.ctaInner {
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  display: grid;
-  gap: 1.1rem;
-  padding-inline: 24px;
-  box-sizing: border-box;
-  padding: clamp(2.1rem, 4.2vw, 3rem);
-  border-radius: 1.2rem;
-  border: 1px solid var(--oomol-divider);
-  background: var(--oomol-bg-container);
-  box-shadow: none;
-}
-
-.ctaTitle {
-  max-width: 100%;
-  color: var(--oomol-text-primary);
-}
-
-.ctaDescription {
-  max-width: 42rem;
-  color: var(--oomol-text-secondary);
-}
-
-/* CTA pair — styling comes from the Button component (variant + size). */
-
-/* ── English overrides ── */
-
-:global(html[lang="en"]) .sectionTitle,
-:global(html[lang="en"]) .ctaTitle {
-  max-width: 100%;
-  font-size: var(--oomol-display-section);
-  line-height: 1.06;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 @media (min-width: 997px) {
   .container {
-    grid-template-columns: minmax(0, 0.88fr) minmax(0, 1.12fr);
+    grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
   }
 
   .cloudCardStack {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
-
-  .cloudCard {
-    &:not(:last-child) {
-      border-bottom: 0;
-    }
-  }
-
-  .cloudCard:nth-child(odd) {
-    border-right: 1px solid var(--oomol-divider);
-  }
-
-  .stepWatermark {
-    top: clamp(2rem, 5vw, 4rem);
-    right: 4vw;
-    font-size: clamp(8rem, 22vw, 18rem);
-  }
 }
-
-/* ── Tablet ── */
-
-@media (max-width: 996px) {
-  .section {
-    overflow: visible;
-  }
-
-  .stepWatermark {
-    display: none;
-  }
-}
-
-/* ── Mobile ── */
 
 @media (max-width: 768px) {
-  .container,
-  .ctaInner {
-    padding-inline: 16px;
-  }
-
   .section {
     padding: 3rem 0;
   }
 
-  .sectionTitle,
-  .ctaTitle {
-    max-width: 100%;
-    text-wrap: pretty;
-  }
-
-  .sectionDescription,
-  .ctaDescription {
-    font-size: var(--oomol-body-base);
-    line-height: 1.62;
-  }
-
-  .videoCardInner,
-  .videoCardMedia,
-  .imageCardMedia {
-    min-height: 12rem;
-  }
-
-  .videoCardPlay {
-    width: 3.2rem;
-    height: 3.2rem;
-  }
-
-  .videoCardTriangle {
-    border-top-width: 0.5rem;
-    border-bottom-width: 0.5rem;
-    border-left-width: 0.8rem;
-  }
-
-  .stepWatermark {
-    display: none;
-  }
-
-  .inlineActions {
-    gap: 1rem;
-  }
-}
-
-@media (max-width: 480px) {
-  .container,
-  .ctaInner {
-    padding-inline: 12px;
+  .container {
+    width: min(100%, calc(100% - 40px));
+    gap: 1.25rem;
   }
 
   .copyPanel {
     gap: 0.85rem;
   }
 
-  .inlineActions {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.8rem;
+  .sectionTitle {
+    max-width: 100%;
+    font-size: var(--oomol-display-section);
+    line-height: 1.1;
   }
 
-  .primaryLink,
-  .secondaryLink {
-    justify-content: space-between;
+  .sectionDescription {
+    font-size: var(--oomol-body-base);
+    line-height: 1.6;
+  }
+
+  .inlineActions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.7rem;
   }
 
   .videoCardMeta {
-    padding: 0.9rem 0.95rem 1rem;
+    padding: 0.9rem 1rem 1rem;
+  }
+
+  .cloudCardStack {
+    gap: 0.65rem;
   }
 
   .cloudCard {
-    padding: 1rem;
+    padding: 0.95rem 1rem;
   }
 }
 
-/* ── Dark mode ── */
-
-[data-theme="dark"] {
-  .section {
-    padding-top: clamp(5rem, 10vw, 8rem);
-    padding-bottom: clamp(5rem, 10vw, 8rem);
+@media (max-width: 480px) {
+  .container {
+    width: min(100%, calc(100% - 32px));
   }
 
+  .sectionTitle {
+    font-size: var(--oomol-display-card);
+    line-height: 1.14;
+  }
+
+  .videoCardMedia,
+  .imageCardMedia {
+    aspect-ratio: 4 / 3;
+  }
+}
+
+[data-theme="dark"] {
   .sectionTint,
   .cliSection {
     background: var(--oomol-bg-base);
@@ -578,50 +308,18 @@
     background: var(--oomol-bg-container);
   }
 
-  .stepWatermark {
-    -webkit-text-stroke: 1px var(--oomol-border-default);
-    opacity: 0.9;
-  }
-
-  .cloudCardStack,
-  .terminalPanel,
   .mediaPanel,
-  .agentMediaCard {
+  .cloudCard {
     border-color: var(--oomol-border-subtle);
     background: var(--oomol-bg-elevated);
-  }
-
-  .cloudCard:hover {
-    background: var(--oomol-bg-spotlight);
   }
 
   .videoCardMeta {
     border-top-color: var(--oomol-border-subtle);
     background: var(--oomol-bg-elevated);
   }
-
-  .videoCardInner,
-  .videoCardMedia,
-  .imageCardMedia {
-    background: var(--oomol-bg-spotlight);
-  }
-
-  .videoCardPlay {
-    background: rgba(255, 255, 255, 0.95);
-  }
-
-  .videoCardTriangle {
-    border-left-color: var(--oomol-text-inverse);
-  }
-
-  .ctaInner {
-    border-color: var(--oomol-border-default);
-    background: var(--oomol-bg-elevated);
-  }
 }
 
-:global(html[lang="en"]) .introTitle,
-:global(html[lang="en"]) .sectionTitle,
-:global(html[lang="en"]) .ctaTitle {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 22ch;
 }

--- a/src/components/HomepageWhyOomol/index.tsx
+++ b/src/components/HomepageWhyOomol/index.tsx
@@ -1,7 +1,7 @@
 import styles from "./styles.module.scss";
 
-import { translate } from "@docusaurus/Translate";
 import Link from "@docusaurus/Link";
+import { translate } from "@docusaurus/Translate";
 import { Button } from "@site/src/components/ui/button";
 import React from "react";
 

--- a/src/components/SiteCta/styles.module.scss
+++ b/src/components/SiteCta/styles.module.scss
@@ -1,36 +1,34 @@
 .section {
   width: 100%;
-  /* Breathing room before footer while staying on the spotlight band (no body-white strip). */
   padding: clamp(5rem, 10vw, 8rem) 0 clamp(3.5rem, 7vw, 5.5rem);
   background: var(--oomol-bg-spotlight);
-  border-bottom: none;
 }
 
 .inner {
   width: min(1200px, calc(100% - 48px));
   margin: 0 auto;
   display: grid;
-  gap: 1.1rem;
-  padding: clamp(2.4rem, 5vw, 4rem) clamp(2rem, 4.2vw, 3rem);
-  border-radius: 14px;
-  border: 1px solid var(--oomol-border-default);
-  /* Clear lift from the band: light = white card on spotlight; dark = elevated panel on container band. */
-  background: var(--oomol-bg-base);
-  box-shadow: none;
   justify-items: center;
+  gap: 1rem;
+  padding: clamp(2.2rem, 5vw, 3.5rem) clamp(1.8rem, 4vw, 2.8rem);
+  border: 1px solid var(--oomol-border-default);
+  border-radius: 14px;
+  background: var(--oomol-bg-base);
   text-align: center;
 }
 
 .title {
   margin: 0;
-  max-width: 22ch;
+  max-width: 24ch;
   font-family: var(--oomol-font-display);
   font-size: var(--oomol-display-section);
-  line-height: 1.06;
+  line-height: 1.08;
   letter-spacing: var(--oomol-tracking-section);
   font-weight: 600;
-  text-wrap: balance;
   color: var(--oomol-text-primary);
+  text-wrap: balance;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .description {
@@ -40,17 +38,16 @@
   line-height: var(--oomol-line-height-relaxed);
   letter-spacing: var(--oomol-tracking-body);
   color: var(--oomol-text-secondary);
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .actions {
   display: flex;
   flex-wrap: wrap;
-  /* Top-align rows so a caption under one control (e.g. DownloadButton note) does not
-     vertically center the shorter sibling — primary/secondary buttons stay on one line. */
-  align-items: flex-start;
   justify-content: center;
-  gap: 0.7rem 1rem;
-  padding-top: 0.8rem;
+  gap: 0.75rem 1rem;
+  padding-top: 0.4rem;
 }
 
 .ghostLink {
@@ -58,63 +55,51 @@
   align-items: center;
   justify-content: center;
   min-width: 10rem;
-  height: 48px;
   min-height: 48px;
   padding: 0 1.25rem;
+  border: 1px solid var(--oomol-border-strong);
   border-radius: var(--ifm-global-radius);
+  background: transparent;
+  color: var(--oomol-text-primary);
   font-size: var(--oomol-body-base);
   font-weight: 500;
-  letter-spacing: var(--oomol-tracking-body);
   text-decoration: none;
-  color: var(--oomol-text-primary);
-  border: 1px solid var(--oomol-border-strong);
-  background: transparent;
-  transition:
-    background-color 0.15s ease,
-    border-color 0.15s ease;
+}
 
-  &:hover {
-    text-decoration: none;
-    background: var(--oomol-hover-bg);
-    color: var(--oomol-text-primary);
-  }
+.ghostLink:hover {
+  text-decoration: none;
+  background: var(--oomol-hover-bg);
 }
 
 .actionButton {
-  /* styling from Button component */
-}
-
-:global(html[lang="en"]) .title {
-  max-width: 26ch;
-  font-size: var(--oomol-display-section);
+  width: auto;
 }
 
 @media (max-width: 768px) {
   .section {
-    padding: 3.4rem 0 clamp(2.5rem, 5vw, 3.5rem);
+    padding: 3rem 0 2.6rem;
   }
 
   .inner {
     width: min(100%, calc(100% - 40px));
-    padding: 2rem 1.4rem 2.2rem;
+    padding: 1.8rem 1.2rem 2rem;
   }
 
   .title {
     max-width: 100%;
-    text-wrap: pretty;
     font-size: var(--oomol-display-section);
   }
 
   .description {
     font-size: var(--oomol-body-base);
-    line-height: var(--oomol-line-height-relaxed);
+    line-height: 1.6;
   }
 
   .actions {
     width: 100%;
     max-width: 20rem;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
   }
 
   .ghostLink,
@@ -124,28 +109,14 @@
 }
 
 @media (max-width: 480px) {
-  .section {
-    padding: 2.6rem 0 2.2rem;
-  }
-
   .inner {
     width: min(100%, calc(100% - 32px));
-    gap: 0.9rem;
     padding: 1.5rem 1rem 1.65rem;
   }
 
   .title {
     font-size: var(--oomol-display-card);
     line-height: 1.14;
-  }
-
-  .description {
-    line-height: 1.56;
-  }
-
-  .actions {
-    max-width: 100%;
-    padding-top: 0.5rem;
   }
 }
 
@@ -155,8 +126,6 @@
   }
 
   .inner {
-    border-color: var(--oomol-border-default);
     background: var(--oomol-bg-elevated);
-    box-shadow: none;
   }
 }

--- a/src/components/magic/animated-beam.tsx
+++ b/src/components/magic/animated-beam.tsx
@@ -1,4 +1,4 @@
-import type {RefObject} from "react";
+import type { RefObject } from "react";
 
 /* Animated beam pattern adapted from Magic UI (MIT) — https://magicui.design/docs/components/animated-beam */
 

--- a/src/components/magic/copilot-beam-brand-icons.tsx
+++ b/src/components/magic/copilot-beam-brand-icons.tsx
@@ -2,7 +2,6 @@ import styles from "./copilot-beam-brand-icons.module.scss";
 
 import { useId } from "react";
 
-
 /**
  * Brand-colored SaaS marks (inline SVG) for the co-pilot beam hero.
  * UnoCSS Simple Icons use currentColor → monochrome; these match Magic UI–style previews.
@@ -80,11 +79,25 @@ export function CopilotBeamIconWhatsApp() {
       aria-hidden
     >
       <defs>
-        <linearGradient id={gid} x1="85.915" x2="86.535" y1="32.567" y2="137.092" gradientUnits="userSpaceOnUse">
+        <linearGradient
+          id={gid}
+          x1="85.915"
+          x2="86.535"
+          y1="32.567"
+          y2="137.092"
+          gradientUnits="userSpaceOnUse"
+        >
           <stop offset="0" stopColor="#57d163" />
           <stop offset="1" stopColor="#23b33a" />
         </linearGradient>
-        <filter id={fid} width="1.115" height="1.114" x="-0.057" y="-0.057" colorInterpolationFilters="sRGB">
+        <filter
+          id={fid}
+          width="1.115"
+          height="1.114"
+          x="-0.057"
+          y="-0.057"
+          colorInterpolationFilters="sRGB"
+        >
           <feGaussianBlur stdDeviation="3.531" />
         </filter>
       </defs>
@@ -113,7 +126,12 @@ export function CopilotBeamIconWhatsApp() {
 /** Compact Google Docs–style mark (multi-color), avoids heavy mask stacks from full brand SVG. */
 export function CopilotBeamIconGoogleDocs() {
   return (
-    <svg className={styles.svgDocs} viewBox="0 0 47 65" xmlns="http://www.w3.org/2000/svg" aria-hidden>
+    <svg
+      className={styles.svgDocs}
+      viewBox="0 0 47 65"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
       <path
         fill="#4285F4"
         d="M4 0h25.4L47 17.6v43c0 2.4-2 4.4-4.4 4.4H4c-2.4 0-4.4-2-4.4-4.4V4C0 2 2 0 4 0z"
@@ -145,7 +163,10 @@ export function CopilotBeamIconZapier() {
         d="M100.487 14.8297C96.4797 14.8297 93.2136 15.434 90.6892 16.6429C88.3376 17.6963 86.3568 19.4321 85.0036 21.6249C83.7091 23.8321 82.8962 26.2883 82.6184 28.832L93.1602 30.3135C93.5415 28.0674 94.3042 26.4754 95.4482 25.5373C96.7486 24.5562 98.3511 24.0605 99.9783 24.136C102.118 24.136 103.67 24.7079 104.634 25.8519C105.59 26.9959 106.076 28.5803 106.076 30.6681V31.7091H95.9401C90.7807 31.7091 87.0742 32.8531 84.8206 35.1411C82.5669 37.429 81.442 40.4492 81.4458 44.2014C81.4458 48.0452 82.5707 50.9052 84.8206 52.7813C87.0704 54.6574 89.8999 55.5897 93.3089 55.5783C97.5379 55.5783 100.791 54.1235 103.067 51.214C104.412 49.426 105.372 47.3793 105.887 45.2024H106.27L107.723 54.7546H117.275V30.5651C117.275 25.5659 115.958 21.6936 113.323 18.948C110.688 16.2024 106.409 14.8297 100.487 14.8297ZM103.828 44.6475C102.312 45.9116 100.327 46.5408 97.8562 46.5408C95.8199 46.5408 94.4052 46.1843 93.6121 45.4712C93.2256 45.1338 92.9182 44.7155 92.7116 44.246C92.505 43.7764 92.4043 43.2671 92.4166 42.7543C92.3941 42.2706 92.4702 41.7874 92.6403 41.3341C92.8104 40.8808 93.071 40.4668 93.4062 40.1174C93.7687 39.7774 94.1964 39.5145 94.6633 39.3444C95.1303 39.1743 95.6269 39.1006 96.1231 39.1278H106.093V39.7856C106.113 40.7154 105.919 41.6374 105.527 42.4804C105.134 43.3234 104.553 44.0649 103.828 44.6475Z"
         fill="#201515"
       />
-      <path d="M175.035 15.7391H163.75V54.7833H175.035V15.7391Z" fill="#201515" />
+      <path
+        d="M175.035 15.7391H163.75V54.7833H175.035V15.7391Z"
+        fill="#201515"
+      />
       <path
         d="M241.666 15.7391C238.478 15.7391 235.965 16.864 234.127 19.1139C232.808 20.7307 231.805 23.1197 231.119 26.2809H230.787L229.311 15.7391H219.673V54.7775H230.959V34.7578C230.959 32.2335 231.55 30.2982 232.732 28.9521C233.914 27.606 236.095 26.933 239.275 26.933H243.559V15.7391H241.666Z"
         fill="#201515"
@@ -172,7 +193,12 @@ export function CopilotBeamIconMessenger() {
   const gid = `msg-g-${uid}`;
 
   return (
-    <svg className={styles.svg} viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" aria-hidden>
+    <svg
+      className={styles.svg}
+      viewBox="0 0 48 48"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
       <defs>
         <radialGradient
           id={gid}

--- a/src/components/magic/homepage-hero-beam.tsx
+++ b/src/components/magic/homepage-hero-beam.tsx
@@ -5,7 +5,6 @@ import { AnimatedBeam } from "@site/src/components/magic/animated-beam";
 import { useReducedMotion } from "framer-motion";
 import React, { useRef } from "react";
 
-
 /**
  * Magic UI–style integration strip: Agents → oo-cli → Studio → Cloud.
  */
@@ -18,7 +17,10 @@ export function HomepageHeroBeam() {
   const cloudRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div className={styles.flow} aria-label={translate({ message: "HOME.FirstScreen.flow.aria" })}>
+    <div
+      className={styles.flow}
+      aria-label={translate({ message: "HOME.FirstScreen.flow.aria" })}
+    >
       <div ref={containerRef} className={styles.flowInner}>
         {!reduceMotion ? (
           <>

--- a/src/components/magic/terminal.tsx
+++ b/src/components/magic/terminal.tsx
@@ -1,12 +1,12 @@
 import styles from "./terminal.module.scss";
 
-import type {HTMLMotionProps, MotionProps} from "motion/react";
-import type {ComponentType, ReactNode, RefAttributes} from "react";
+import type { HTMLMotionProps, MotionProps } from "motion/react";
+import type { ComponentType, ReactNode, RefAttributes } from "react";
 
 /* Terminal + typing sequence adapted from Magic UI (MIT) — https://magicui.design/docs/components/terminal */
 
 import { cn } from "@site/src/lib/utils";
-import { motion, useInView   } from "motion/react";
+import { motion, useInView } from "motion/react";
 import {
   Children,
   createContext,
@@ -14,12 +14,8 @@ import {
   useEffect,
   useMemo,
   useRef,
-  useState
-  
-  
-  
+  useState,
 } from "react";
-
 
 interface SequenceContextValue {
   completeItem: (index: number) => void;
@@ -115,7 +111,10 @@ export function AnimatedSpan({
             ? { opacity: 1, y: 0 }
             : { opacity: 0, y: -5 }
       }
-      transition={{ duration: staticMode ? 0 : 0.3, delay: sequence ? 0 : delay / 1000 }}
+      transition={{
+        duration: staticMode ? 0 : 0.3,
+        delay: sequence ? 0 : delay / 1000,
+      }}
       className={cn(className)}
       onAnimationComplete={() => {
         if (staticMode) {
@@ -291,7 +290,11 @@ export function Terminal({
   });
 
   const [activeIndex, setActiveIndex] = useState(0);
-  const sequenceHasStarted = staticMode ? true : sequence ? !startOnView || isInView : false;
+  const sequenceHasStarted = staticMode
+    ? true
+    : sequence
+      ? !startOnView || isInView
+      : false;
 
   const contextValue = useMemo<SequenceContextValue | null>(() => {
     if (!sequence || staticMode) {

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -26,10 +26,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
     {...props}
   >
     {children}
-    <i
-      className="i-lucide-chevron-right ml-auto size-4"
-      aria-hidden="true"
-    />
+    <i className="i-lucide-chevron-right ml-auto size-4" aria-hidden="true" />
   </DropdownMenuPrimitive.SubTrigger>
 ));
 DropdownMenuSubTrigger.displayName =
@@ -139,8 +136,7 @@ const DropdownMenuRadioItem = React.forwardRef<
     {children}
   </DropdownMenuPrimitive.RadioItem>
 ));
-DropdownMenuRadioItem.displayName =
-  DropdownMenuPrimitive.RadioItem.displayName;
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,
@@ -170,8 +166,7 @@ const DropdownMenuSeparator = React.forwardRef<
     {...props}
   />
 ));
-DropdownMenuSeparator.displayName =
-  DropdownMenuPrimitive.Separator.displayName;
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
 const DropdownMenuShortcut = ({
   className,

--- a/src/pages/app/index.tsx
+++ b/src/pages/app/index.tsx
@@ -293,7 +293,8 @@ const COPY = {
     },
     models: {
       title: "Better for everyday use",
-      description: "Search, execution, results, and follow-up work all stay in one workspace.",
+      description:
+        "Search, execution, results, and follow-up work all stay in one workspace.",
       demo: {
         eyebrow: "One workspace",
         title: "Keep the task moving in one workspace",
@@ -311,7 +312,8 @@ const COPY = {
         },
         image: {
           eyebrow: "Follow-up",
-          title: "Better for reviewing results, asking follow-up questions, and continuing the work",
+          title:
+            "Better for reviewing results, asking follow-up questions, and continuing the work",
           body: "Once you have the result, you can refine the request, ask follow-up questions, or continue the next action without switching to another interface.",
           chips: ["Review result", "Ask follow-up", "Keep going"],
         },
@@ -361,7 +363,8 @@ const COPY = {
       ],
     },
     outputs: {
-      title: "Terminals are great for integration. GUIs are better for ongoing use.",
+      title:
+        "Terminals are great for integration. GUIs are better for ongoing use.",
       description:
         "Use oo-cli when you want tools connected into agents and terminal workflows. Open OOMOL AI when you want to use those same tools yourself in a visual workspace.",
       imageAlt:
@@ -909,7 +912,10 @@ export default function AppPage() {
           </div>
         </section>
 
-        <section id="pricing" className={cx(styles.section, styles.sectionMuted)}>
+        <section
+          id="pricing"
+          className={cx(styles.section, styles.sectionMuted)}
+        >
           <div className={cx(styles.sectionIntro, styles.pricingIntro)}>
             <h2 className={styles.hangingTitle}>
               {renderHangingTitleLine(

--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -366,7 +366,6 @@ export default function Downloads() {
               })}
             </div>
           </section>
-
         </div>
 
         <SiteCta

--- a/src/pages/downloads/styles.module.scss
+++ b/src/pages/downloads/styles.module.scss
@@ -10,7 +10,6 @@
   padding: clamp(3.1rem, 6.2vw, 5rem) 0 clamp(2rem, 3.2vw, 2.8rem);
   background: var(--oomol-bg-base);
   border-bottom: 1px solid var(--oomol-divider);
-
 }
 
 .heroInner {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -12,12 +12,7 @@ import React from "react";
 
 import Layout from "../theme/Layout";
 
-type PerfSection =
-  | "hero"
-  | "toolstrip"
-  | "painpoints"
-  | "why"
-  | "flow";
+type PerfSection = "hero" | "toolstrip" | "painpoints" | "why" | "flow";
 
 const PERF_SECTION_KEYS: PerfSection[] = [
   "hero",

--- a/src/pages/studio/index.tsx
+++ b/src/pages/studio/index.tsx
@@ -259,11 +259,7 @@ export default function StudioPage() {
           actions={
             <>
               <DownloadButton centered showNote noteTone="inverse" />
-              <Button
-                asChild
-                size="lg"
-                variant="outline"
-              >
+              <Button asChild size="lg" variant="outline">
                 <Link to="/cloud">
                   {translate({ message: "HOME.StudioChain.action.cloud" })}
                 </Link>

--- a/src/pages/studio/styles.module.scss
+++ b/src/pages/studio/styles.module.scss
@@ -8,7 +8,6 @@
   border-bottom: 1px solid var(--oomol-divider);
   position: relative;
   overflow: clip;
-
 }
 
 .sectionContainer {

--- a/src/theme/Footer/styles.module.scss
+++ b/src/theme/Footer/styles.module.scss
@@ -1,281 +1,123 @@
-@use "../../css/mixins.scss" as *;
-
-/* Same runway as SiteCta: spotlight band. Use padding (not margin-top) so no body-white “sandwich” gap. */
 .root {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
   width: 100%;
-  margin-top: 0;
-  box-sizing: border-box;
-  /* Horizontal inset so blocks never hug the viewport edge on ultra-wide screens. */
-  padding: clamp(2rem, 5vw, 3.5rem) clamp(20px, 4vw, 36px)
-    clamp(1.5rem, 3vw, 2rem);
+  padding: clamp(2rem, 5vw, 3rem) 0 1.5rem;
   background: var(--oomol-bg-spotlight);
-  border-top: none;
 }
 
 .center {
-  width: 100%;
-  max-width: 1200px;
+  width: min(1200px, calc(100% - 40px));
   margin: 0 auto;
-  padding: 0;
-  box-sizing: border-box;
-
-  @include phone {
-    max-width: 100%;
-  }
-
-  @include phone-middle {
-    max-width: 100%;
-  }
-
-  @include phone-large {
-    max-width: 100%;
-  }
 }
 
 .content {
   display: grid;
-  gap: clamp(2rem, 4vw, 3rem);
-  grid-template-areas:
-    "brand"
-    "links";
-}
-
-/* Desktop: one grid — fixed brand track + fluid link matrix (four equal columns, no space-between “void”). */
-@media screen and (min-width: 1000px) {
-  .content {
-    grid-template-columns: minmax(11rem, 13.5rem) minmax(0, 1fr);
-    grid-template-areas: "brand links";
-    align-items: start;
-    column-gap: clamp(2.25rem, 4.5vw, 3.75rem);
-    row-gap: 0;
-  }
+  gap: 1.75rem;
 }
 
 .leftBox {
-  grid-area: brand;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  align-items: center;
-  text-align: center;
-}
-
-@media screen and (min-width: 1000px) {
-  .leftBox {
-    align-items: flex-start;
-    text-align: left;
-  }
-}
-
-@media (max-width: 768px) {
-  .leftBox {
-    align-items: flex-start;
-    text-align: left;
-    gap: 0.85rem;
-  }
+  display: grid;
+  gap: 0.85rem;
+  justify-items: start;
+  text-align: left;
 }
 
 .leftBoxLogo {
   display: flex;
 }
 
+.iconOutBox {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+}
+
 .links {
-  grid-area: links;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 1.75rem 1.25rem;
-  width: 100%;
+  gap: 1.25rem 1rem;
   min-width: 0;
 }
 
-@media screen and (min-width: 768px) {
-  .links {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    column-gap: clamp(1rem, 2vw, 1.5rem);
-  }
-}
-
-/* Cap width + align end: brand left, compact link matrix sits on the right — balances the rail. */
-@media screen and (min-width: 1000px) {
-  .links {
-    width: min(100%, 42rem);
-    justify-self: end;
-  }
-}
-
 .category {
-  display: flex;
-  flex-direction: column;
-  gap: 0.55rem;
-  flex: 1;
+  display: grid;
+  gap: 0.45rem;
   min-width: 0;
 }
 
 .items {
-  display: flex;
-  flex-direction: column;
-  gap: 0.05rem;
+  display: grid;
+  gap: 0.1rem;
 }
 
 .title {
+  margin: 0;
   font-family: var(--oomol-font-display);
   font-size: var(--oomol-font-size-sm);
   font-weight: 600;
   letter-spacing: -0.012em;
   color: var(--oomol-text-primary);
-  margin-bottom: 0.1rem;
 }
 
 .item {
   font-size: var(--oomol-body-base);
   line-height: 1.5;
-  padding: 0.12rem 0;
 }
 
 .link {
-  font-weight: 400;
   color: var(--oomol-text-secondary);
   text-decoration: none;
   border-radius: 4px;
   transition: color 0.15s ease;
+}
 
-  &:hover {
-    color: var(--oomol-text-primary);
-  }
+.link:hover {
+  color: var(--oomol-text-primary);
+}
 
-  &:focus-visible {
-    outline: 2px solid var(--oomol-primary);
-    outline-offset: 2px;
-  }
+.link:focus-visible {
+  outline: 2px solid var(--oomol-primary);
+  outline-offset: 2px;
 }
 
 .border {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  min-height: 4rem;
-  margin-top: clamp(1.5rem, 3vw, 2.25rem);
-  padding-top: clamp(1rem, 2vw, 1.25rem);
+  width: min(1200px, calc(100% - 40px));
+  margin: 1.5rem auto 0;
+  padding-top: 1rem;
   border-top: 1px solid var(--oomol-border-default);
-  box-sizing: border-box;
 }
 
 .bottom {
-  width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  min-height: 48px;
-  display: flex;
-  align-items: center;
-  padding: 0;
-  justify-content: space-between;
-  gap: 12px;
-
-  @include phone {
-    width: 100%;
-    height: auto;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 12px;
-    padding: 0 0 12px;
-    margin-bottom: 0;
-  }
-
-  @include phone-middle {
-    width: 100%;
-    height: auto;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 12px;
-    padding: 0 0 12px;
-    margin-bottom: 0;
-  }
-
-  @include phone-large {
-    width: 100%;
-    height: auto;
-    flex-direction: column;
-    align-items: stretch;
-    gap: 12px;
-    padding: 0 0 12px;
-    margin-bottom: 0;
-  }
-
-  @include pad {
-    flex-wrap: wrap;
-    justify-content: space-between;
-    align-items: center;
-  }
+  display: grid;
+  gap: 0.9rem;
 }
 
-@media (max-width: 640px) {
-  .bottom {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 14px;
-    padding-bottom: 0;
-  }
+.bottomInfo {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+  font-size: var(--oomol-body-sm);
+  line-height: 1.58;
+  color: var(--oomol-text-tertiary);
+}
+
+.bottomInfo a {
+  display: inline-flex;
+  width: fit-content;
+  margin-left: 0;
+  color: var(--oomol-text-secondary);
+}
+
+.bottomInfo a:hover {
+  color: var(--oomol-primary);
 }
 
 .rightControls {
   display: flex;
-  align-items: center;
   flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 10px;
-  flex-shrink: 0;
-  row-gap: 10px;
-}
-
-@media (max-width: 640px) {
-  .rightControls {
-    align-items: flex-start;
-    flex-wrap: wrap;
-    width: 100%;
-    justify-content: flex-start;
-  }
-
-  .rightControls > * {
-    flex: 0 1 auto;
-    max-width: 100%;
-  }
-}
-
-.bottomInfo {
-  font-size: var(--oomol-body-mono);
-  line-height: 1.45;
-  color: var(--oomol-text-tertiary);
-  text-align: left;
-  flex: 1 1 auto;
-  min-width: 0;
-
-  a {
-    margin-left: 8px;
-    color: var(--oomol-text-secondary);
-
-    &:hover {
-      color: var(--oomol-primary);
-    }
-  }
-}
-
-@media (max-width: 640px) {
-  .bottomInfo {
-    font-size: var(--oomol-body-sm);
-    line-height: 1.58;
-    display: flex;
-    flex-direction: column;
-    gap: 0.35rem;
-  }
-
-  .bottomInfo a {
-    display: inline-flex;
-    margin-left: 0;
-  }
+  gap: 0.6rem;
+  align-items: center;
+  justify-content: flex-start;
 }
 
 .cookieControlButton {
@@ -284,9 +126,9 @@
 }
 
 .footerControlSurface {
-  min-height: 36px;
-  min-width: fit-content;
+  min-width: 0;
   max-width: 100%;
+  min-height: 38px;
   padding-inline: 0.9rem;
   border-radius: 999px;
   justify-content: flex-start;
@@ -294,39 +136,28 @@
   white-space: nowrap;
 }
 
-@media (max-width: 640px) {
-  .footerControlSurface {
-    min-height: 38px;
-    min-width: 0;
-  }
-}
-
 .cookieControlIcon {
   flex: none;
   font-size: var(--oomol-font-size-sm);
 }
 
-.iconOutBox {
+.iconBox {
+  width: 36px;
+  height: 36px;
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  min-height: 40px;
-  margin-top: 0.35rem;
-  gap: 0.45rem;
   justify-content: center;
+  color: var(--oomol-text-tertiary);
+  border-radius: var(--ifm-global-radius);
+  background: transparent;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
 }
 
-@media screen and (min-width: 1000px) {
-  .iconOutBox {
-    justify-content: flex-start;
-  }
-}
-
-@media (max-width: 768px) {
-  .iconOutBox {
-    justify-content: flex-start;
-    margin-top: 0;
-  }
+.iconBox:hover {
+  color: var(--oomol-text-primary);
+  background: var(--oomol-hover-bg);
 }
 
 .socialIcon {
@@ -340,67 +171,61 @@
   font-size: calc(var(--oomol-font-size-xl) + 0.125rem);
 }
 
-.iconBox {
-  width: 36px;
-  height: 36px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--oomol-text-tertiary);
-  border-radius: var(--ifm-global-radius);
-  border: 0;
-  background: transparent;
-  box-shadow: none;
-  transition:
-    color 0.15s ease,
-    background-color 0.15s ease;
-
-  &:hover {
-    color: var(--oomol-text-primary);
-    background: var(--oomol-hover-bg);
-    border-color: transparent;
-    box-shadow: none;
-    transform: none;
-  }
-}
-
 .work-weixin {
   width: 24px;
   height: 24px;
 }
 
 .qrcode {
-  max-width: none;
   width: 160px;
   height: 160px;
+  max-width: none;
+}
+
+@media (min-width: 1000px) {
+  .content {
+    grid-template-columns: minmax(12rem, 14rem) minmax(0, 1fr);
+    align-items: start;
+    gap: 3rem;
+  }
+
+  .links {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem 1.25rem;
+  }
+
+  .bottom {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .rightControls {
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 480px) {
+  .center,
+  .border {
+    width: min(100%, calc(100% - 32px));
+  }
+
+  .links {
+    gap: 1rem 0.85rem;
+  }
 }
 
 [data-theme="dark"] {
   .root {
     background: var(--oomol-bg-container);
-    border-top-color: var(--oomol-border-subtle);
   }
 
   .border {
     border-top-color: var(--oomol-border-default);
   }
 
-  .iconBox {
-    color: var(--oomol-text-tertiary);
-    background: transparent;
-    border: 0;
-    box-shadow: none;
-
-    &:hover {
-      color: var(--oomol-text-primary);
-      background: var(--oomol-hover-bg);
-      border-color: transparent;
-      box-shadow: none;
-    }
+  .iconBox:hover {
+    background: var(--oomol-hover-bg);
   }
-
-  .cookieControlButton {
-    font-weight: 500;
-  }
-
 }

--- a/src/theme/Navbar/styles.module.scss
+++ b/src/theme/Navbar/styles.module.scss
@@ -132,7 +132,8 @@
 }
 
 /* 浅色非激活：与 custom.scss 里 [data-theme="light"] .navbar__link 一致（ghost 默认是 secondary，会偏浅） */
-:global([data-theme="light"]) .productMenuTrigger:not(.productMenuTriggerActive) {
+:global([data-theme="light"])
+  .productMenuTrigger:not(.productMenuTriggerActive) {
   color: var(--oomol-text-primary);
 
   &:hover {

--- a/src/theme/components/ColorModeDropdown.tsx
+++ b/src/theme/components/ColorModeDropdown.tsx
@@ -1,7 +1,9 @@
 import styles from "./ColorModeDropdown.module.scss";
 
+import type { ButtonProps } from "@site/src/components/ui/button";
+
 import { translate } from "@docusaurus/Translate";
-import { Button, type ButtonProps } from "@site/src/components/ui/button";
+import { Button } from "@site/src/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/src/theme/components/LocalDropdown.tsx
+++ b/src/theme/components/LocalDropdown.tsx
@@ -1,12 +1,13 @@
 import styles from "./LocalDropdown.module.scss";
 
 import type { DocusaurusContext } from "@docusaurus/types";
+import type { ButtonProps } from "@site/src/components/ui/button";
 
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import { useLocation } from "@docusaurus/router";
 import { useAlternatePageUtils } from "@docusaurus/theme-common/internal";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
-import { Button, type ButtonProps } from "@site/src/components/ui/button";
+import { Button } from "@site/src/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,


### PR DESCRIPTION
## What changed

- simplified the homepage mobile layout chain from `HomepageLinearFlow` through `SiteCta`
- simplified the Cloud page linear flow layout to match the homepage behavior
- simplified the footer mobile structure and spacing
- ran Prettier and fixed the remaining lint-blocking import-order/type-only import issues

## Why it changed

The mobile regressions were concentrated in the sections starting from `01 / 02 / 03`, where the layout had accumulated multiple rounds of responsive overrides. That made mobile behavior harder to reason about and caused clipping on real devices.

This PR replaces those stacked overrides with a simpler layout model:

- desktop: predictable two-column sections where appropriate
- mobile: single-column stacking with text allowed to shrink and wrap safely
- footer: simpler mobile grouping with tighter spacing

## Impact

- fixes mobile clipping in the homepage flow and related sections
- keeps homepage and Cloud page behavior aligned instead of maintaining two divergent responsive implementations
- makes future mobile adjustments easier because the responsive rules are flatter and more consistent

## Validation

- `npm run build`
- `npm run lint`
- manual viewport checks for homepage and Cloud page at mobile widths, including `390px` portrait
