### PR TITLE
[codex] Harden mobile layout rules for WebKit

### DIFF
--- a/src/components/CloudPageDeveloperBenefits/styles.module.scss
+++ b/src/components/CloudPageDeveloperBenefits/styles.module.scss
@@ -5,8 +5,11 @@
 }
 
 .container {
-  width: min(1200px, calc(100% - 48px));
+  width: 100%;
+  max-width: 1200px;
   margin: 0 auto;
+  padding-inline: 24px;
+  box-sizing: border-box;
   display: grid;
   gap: clamp(1.5rem, 3vw, 2.5rem);
 }
@@ -48,7 +51,6 @@
   letter-spacing: var(--oomol-tracking-display);
   font-weight: 600;
   color: var(--oomol-text-primary);
-  text-wrap: balance;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -179,7 +181,7 @@
   }
 
   .container {
-    width: min(100%, calc(100% - 40px));
+    padding-inline: 20px;
   }
 
   .title {
@@ -204,7 +206,7 @@
 
 @media (max-width: 480px) {
   .container {
-    width: min(100%, calc(100% - 32px));
+    padding-inline: 16px;
   }
 
   .title {

--- a/src/components/CloudPageLinearFlow/styles.module.scss
+++ b/src/components/CloudPageLinearFlow/styles.module.scss
@@ -18,8 +18,11 @@
 }
 
 .container {
-  width: min(1200px, calc(100% - 48px));
+  width: 100%;
+  max-width: 1200px;
   margin: 0 auto;
+  padding-inline: 24px;
+  box-sizing: border-box;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: clamp(1.5rem, 3vw, 2.5rem);
@@ -63,7 +66,6 @@
   letter-spacing: var(--oomol-tracking-display);
   font-weight: 600;
   color: var(--oomol-text-primary);
-  text-wrap: balance;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -251,7 +253,7 @@
   }
 
   .container {
-    width: min(100%, calc(100% - 40px));
+    padding-inline: 20px;
     gap: 1.25rem;
   }
 
@@ -283,7 +285,7 @@
 
 @media (max-width: 480px) {
   .container {
-    width: min(100%, calc(100% - 32px));
+    padding-inline: 16px;
   }
 
   .sectionTitle {

--- a/src/components/HomepageGuiEntry/styles.module.scss
+++ b/src/components/HomepageGuiEntry/styles.module.scss
@@ -5,8 +5,11 @@
 }
 
 .container {
-  width: min(1200px, calc(100% - 48px));
+  width: 100%;
+  max-width: 1200px;
   margin: 0 auto;
+  padding-inline: 24px;
+  box-sizing: border-box;
 }
 
 .card {
@@ -53,7 +56,6 @@
   letter-spacing: var(--oomol-tracking-section);
   font-weight: 600;
   color: var(--oomol-text-primary);
-  text-wrap: balance;
   overflow-wrap: anywhere;
 }
 
@@ -125,7 +127,7 @@
   }
 
   .container {
-    width: min(100%, calc(100% - 40px));
+    padding-inline: 20px;
   }
 
   .title {
@@ -151,7 +153,7 @@
 
 @media (max-width: 480px) {
   .container {
-    width: min(100%, calc(100% - 32px));
+    padding-inline: 16px;
   }
 
   .title {

--- a/src/components/HomepageLinearFlow/styles.module.scss
+++ b/src/components/HomepageLinearFlow/styles.module.scss
@@ -23,8 +23,11 @@
 }
 
 .container {
-  width: min(1200px, calc(100% - 48px));
+  width: 100%;
+  max-width: 1200px;
   margin: 0 auto;
+  padding-inline: 24px;
+  box-sizing: border-box;
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: clamp(1.5rem, 3vw, 2.5rem);
@@ -77,7 +80,6 @@
   letter-spacing: var(--oomol-tracking-display);
   font-weight: 600;
   color: var(--oomol-text-primary);
-  text-wrap: balance;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -244,7 +246,7 @@
   }
 
   .container {
-    width: min(100%, calc(100% - 40px));
+    padding-inline: 20px;
     gap: 1.25rem;
   }
 
@@ -284,7 +286,7 @@
 
 @media (max-width: 480px) {
   .container {
-    width: min(100%, calc(100% - 32px));
+    padding-inline: 16px;
   }
 
   .sectionTitle {

--- a/src/components/SiteCta/styles.module.scss
+++ b/src/components/SiteCta/styles.module.scss
@@ -5,12 +5,16 @@
 }
 
 .inner {
-  width: min(1200px, calc(100% - 48px));
+  width: 100%;
+  max-width: 1200px;
   margin: 0 auto;
+  padding-inline: 24px;
+  box-sizing: border-box;
   display: grid;
   justify-items: center;
   gap: 1rem;
-  padding: clamp(2.2rem, 5vw, 3.5rem) clamp(1.8rem, 4vw, 2.8rem);
+  padding-top: clamp(2.2rem, 5vw, 3.5rem);
+  padding-bottom: clamp(2.2rem, 5vw, 3.5rem);
   border: 1px solid var(--oomol-border-default);
   border-radius: 14px;
   background: var(--oomol-bg-base);
@@ -26,7 +30,6 @@
   letter-spacing: var(--oomol-tracking-section);
   font-weight: 600;
   color: var(--oomol-text-primary);
-  text-wrap: balance;
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -81,8 +84,9 @@
   }
 
   .inner {
-    width: min(100%, calc(100% - 40px));
-    padding: 1.8rem 1.2rem 2rem;
+    padding-inline: 20px;
+    padding-top: 1.8rem;
+    padding-bottom: 2rem;
   }
 
   .title {
@@ -110,8 +114,9 @@
 
 @media (max-width: 480px) {
   .inner {
-    width: min(100%, calc(100% - 32px));
-    padding: 1.5rem 1rem 1.65rem;
+    padding-inline: 16px;
+    padding-top: 1.5rem;
+    padding-bottom: 1.65rem;
   }
 
   .title {

--- a/src/theme/Footer/styles.module.scss
+++ b/src/theme/Footer/styles.module.scss
@@ -5,8 +5,11 @@
 }
 
 .center {
-  width: min(1200px, calc(100% - 40px));
+  width: 100%;
+  max-width: 1200px;
   margin: 0 auto;
+  padding-inline: 20px;
+  box-sizing: border-box;
 }
 
 .content {
@@ -81,8 +84,11 @@
 }
 
 .border {
-  width: min(1200px, calc(100% - 40px));
+  width: 100%;
+  max-width: 1200px;
   margin: 1.5rem auto 0;
+  padding-inline: 20px;
+  box-sizing: border-box;
   padding-top: 1rem;
   border-top: 1px solid var(--oomol-border-default);
 }
@@ -208,7 +214,7 @@
 @media (max-width: 480px) {
   .center,
   .border {
-    width: min(100%, calc(100% - 32px));
+    padding-inline: 16px;
   }
 
   .links {


### PR DESCRIPTION
## What changed

- replaces the mobile container width rules in the homepage flow, Cloud page flow, CTA, benefits section, GUI entry, and footer with simpler `max-width + padding-inline` layout constraints
- removes the reliance on `text-wrap` in the affected titles and keeps wrapping behavior on the safer `overflow-wrap` path

## Why it changed

The earlier mobile layout fixes reproduced correctly in Chrome device emulation, but the issue still appeared on real mobile Safari/WebKit environments. The remaining risk was that some of the more advanced layout and wrapping rules were being interpreted differently by real WebKit than by desktop emulation.

This follow-up intentionally switches those sections to more conservative container sizing and text wrapping behavior so the layout is less dependent on browser-specific width calculations.

## Impact

- reduces the chance of right-edge clipping on real iPhone Safari / embedded WebKit views
- keeps the previous mobile layout cleanup intact while making the container logic more robust
- applies the same safety rules to both the homepage flow and the Cloud page flow so they do not drift apart again

## Validation

- `npm run lint`
- `npm run build`
- manual mobile-width verification for homepage and Cloud page at `390px` portrait
