### PR TITLE
[codex] Refactor marketing typography class names

### DIFF
--- a/src/components/CliPageDeveloperBenefits/index.tsx
+++ b/src/components/CliPageDeveloperBenefits/index.tsx
@@ -135,8 +135,8 @@ export default function CliPageDeveloperBenefits() {
       <div className={styles.container}>
         <div className={styles.header}>
           <div className={styles.badge}>{copy.badge}</div>
-          <h2 className={styles.title}>{copy.title}</h2>
-          <p className={styles.subtitle}>{copy.subtitle}</p>
+          <h2 className={styles.sectionTitle}>{copy.title}</h2>
+          <p className={styles.sectionSubtitle}>{copy.subtitle}</p>
         </div>
 
         <div className={styles.grid}>

--- a/src/components/CliPageDeveloperBenefits/styles.module.scss
+++ b/src/components/CliPageDeveloperBenefits/styles.module.scss
@@ -47,11 +47,11 @@
   }
 }
 
-.title {
+.sectionTitle {
   @include marketing-display-title(hero, 16ch, left, 1.06);
 }
 
-.subtitle {
+.sectionSubtitle {
   @include marketing-supporting-copy(32rem, left, 1.6, null);
 }
 
@@ -267,11 +267,11 @@
   max-width: 38rem;
 }
 
-:global(html[lang="en"]) .title {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 20ch;
 }
 
-:global(html[lang="en"]) .subtitle {
+:global(html[lang="en"]) .sectionSubtitle {
   max-width: 42rem;
 }
 
@@ -292,7 +292,7 @@
     max-width: 100%;
   }
 
-  .title {
+  .sectionTitle {
     max-width: 100%;
   }
 }
@@ -306,7 +306,7 @@
     width: min(100%, calc(100% - 40px));
   }
 
-  .subtitle {
+  .sectionSubtitle {
     @include marketing-mobile-supporting-copy();
   }
 

--- a/src/components/CliPageLinearFlow/styles.module.scss
+++ b/src/components/CliPageLinearFlow/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .flow {
   display: grid;
   gap: 0;
@@ -71,24 +73,11 @@
 }
 
 .sectionTitle {
-  margin: 0;
-  max-width: 22ch;
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-section);
-  line-height: 1.06;
-  letter-spacing: var(--oomol-tracking-section);
-  font-weight: 600;
-  color: var(--oomol-text-primary);
-  text-wrap: balance;
+  @include marketing-display-title(section, 22ch, left, 1.06);
 }
 
 .sectionDescription {
-  margin: 0;
-  max-width: 40rem;
-  font-size: var(--oomol-body-lead);
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
-  color: var(--oomol-text-secondary);
+  @include marketing-supporting-copy(40rem);
 }
 
 /* Actions */

--- a/src/components/CliPagePainPoints/index.tsx
+++ b/src/components/CliPagePainPoints/index.tsx
@@ -162,8 +162,8 @@ export default function CliPagePainPoints() {
       <div className={styles.container}>
         <div className={styles.header}>
           <div className={styles.badge}>{copy.badge}</div>
-          <h2 className={styles.title}>{copy.title}</h2>
-          <p className={styles.subtitle}>{copy.subtitle}</p>
+          <h2 className={styles.sectionTitle}>{copy.title}</h2>
+          <p className={styles.sectionSubtitle}>{copy.subtitle}</p>
         </div>
 
         <div className={styles.grid}>

--- a/src/components/CliPagePainPoints/styles.module.scss
+++ b/src/components/CliPagePainPoints/styles.module.scss
@@ -44,11 +44,11 @@
   }
 }
 
-.title {
+.sectionTitle {
   @include marketing-display-title(section, 22ch, left, 1.06);
 }
 
-.subtitle {
+.sectionSubtitle {
   @include marketing-supporting-copy(44rem);
 }
 
@@ -186,11 +186,11 @@
 
 /* ── English overrides ── */
 
-:global(html[lang="en"]) .title {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 26ch;
 }
 
-:global(html[lang="en"]) .subtitle {
+:global(html[lang="en"]) .sectionSubtitle {
   max-width: 48rem;
 }
 
@@ -247,11 +247,11 @@
     }
   }
 
-  .title {
+  .sectionTitle {
     font-size: var(--oomol-display-section);
   }
 
-  .subtitle {
+  .sectionSubtitle {
     @include marketing-mobile-supporting-copy();
   }
 }

--- a/src/components/CloudPageDeveloperBenefits/index.tsx
+++ b/src/components/CloudPageDeveloperBenefits/index.tsx
@@ -103,8 +103,8 @@ export default function CloudPageDeveloperBenefits() {
       <div className={styles.container}>
         <div className={styles.header}>
           <div className={styles.badge}>{copy.badge}</div>
-          <h2 className={styles.title}>{copy.title}</h2>
-          <p className={styles.subtitle}>{copy.subtitle}</p>
+          <h2 className={styles.sectionTitle}>{copy.title}</h2>
+          <p className={styles.sectionSubtitle}>{copy.subtitle}</p>
         </div>
 
         <div className={styles.grid}>

--- a/src/components/CloudPageDeveloperBenefits/styles.module.scss
+++ b/src/components/CloudPageDeveloperBenefits/styles.module.scss
@@ -44,13 +44,13 @@
   background: var(--oomol-primary);
 }
 
-.title {
+.sectionTitle {
   @include marketing-display-title(hero, 18ch, left, 1.08);
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
-.subtitle {
+.sectionSubtitle {
   @include marketing-supporting-copy(38rem);
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -174,12 +174,12 @@
     padding-inline: 20px;
   }
 
-  .title {
+  .sectionTitle {
     max-width: 100%;
     font-size: var(--oomol-display-section);
   }
 
-  .subtitle {
+  .sectionSubtitle {
     @include marketing-mobile-supporting-copy();
   }
 
@@ -198,7 +198,7 @@
     padding-inline: 16px;
   }
 
-  .title {
+  .sectionTitle {
     font-size: var(--oomol-display-card);
     line-height: 1.14;
   }
@@ -221,6 +221,6 @@
   }
 }
 
-:global(html[lang="en"]) .title {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 22ch;
 }

--- a/src/components/CloudPageLinearFlow/styles.module.scss
+++ b/src/components/CloudPageLinearFlow/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .flow {
   display: grid;
   gap: 0;
@@ -60,25 +62,13 @@
 }
 
 .sectionTitle {
-  margin: 0;
-  max-width: 18ch;
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-hero);
-  line-height: 1.08;
-  letter-spacing: var(--oomol-tracking-display);
-  font-weight: 600;
-  color: var(--oomol-text-primary);
+  @include marketing-display-title(hero, 18ch, left, 1.08);
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
 .sectionDescription {
-  margin: 0;
-  max-width: 40rem;
-  font-size: var(--oomol-body-lead);
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
-  color: var(--oomol-text-secondary);
+  @include marketing-supporting-copy(40rem);
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -273,8 +263,7 @@
   }
 
   .sectionDescription {
-    font-size: var(--oomol-body-base);
-    line-height: 1.6;
+    @include marketing-mobile-supporting-copy();
   }
 
   .inlineActions {

--- a/src/components/CloudPagePainPoints/index.tsx
+++ b/src/components/CloudPagePainPoints/index.tsx
@@ -88,8 +88,8 @@ export default function CloudPagePainPoints() {
       <div className={styles.container}>
         <div className={styles.header}>
           <div className={styles.badge}>{copy.badge}</div>
-          <h2 className={styles.title}>{copy.title}</h2>
-          <p className={styles.subtitle}>{copy.subtitle}</p>
+          <h2 className={styles.sectionTitle}>{copy.title}</h2>
+          <p className={styles.sectionSubtitle}>{copy.subtitle}</p>
         </div>
 
         <div className={styles.grid}>

--- a/src/components/CloudPagePainPoints/styles.module.scss
+++ b/src/components/CloudPagePainPoints/styles.module.scss
@@ -46,11 +46,11 @@
   }
 }
 
-.title {
+.sectionTitle {
   @include marketing-display-title(section, 22ch, left, 1.06);
 }
 
-.subtitle {
+.sectionSubtitle {
   @include marketing-supporting-copy(48rem);
 }
 
@@ -150,11 +150,11 @@
   }
 }
 
-:global(html[lang="en"]) .title {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 26ch;
 }
 
-:global(html[lang="en"]) .subtitle {
+:global(html[lang="en"]) .sectionSubtitle {
   max-width: 52rem;
 }
 
@@ -183,11 +183,11 @@
     width: min(100%, calc(100% - 40px));
   }
 
-  .title {
+  .sectionTitle {
     font-size: var(--oomol-display-section);
   }
 
-  .subtitle {
+  .sectionSubtitle {
     @include marketing-mobile-supporting-copy();
   }
 

--- a/src/components/HomePageBuiltInLLM/index.tsx
+++ b/src/components/HomePageBuiltInLLM/index.tsx
@@ -101,10 +101,10 @@ export default function HomePageBuiltInLLM() {
   return (
     <div className={styles.container}>
       <div className={styles.content}>
-        <h2 className={styles.title}>
+        <h2 className={styles.sectionTitle}>
           {translate({ id: "HOME.Built-in.title" })}
         </h2>
-        <p className={styles.subtitle}>
+        <p className={styles.sectionSubtitle}>
           {translate({ id: "HOME.Built-in.subtitle" })}
         </p>
       </div>

--- a/src/components/HomePageBuiltInLLM/styles.module.scss
+++ b/src/components/HomePageBuiltInLLM/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .container {
   display: flex;
   flex-direction: column;
@@ -27,24 +29,15 @@
   margin-bottom: 24px;
 }
 
-.title {
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-section);
-  font-weight: 600;
-  color: var(--oomol-text-primary);
+.sectionTitle {
+  @include marketing-display-title(section, null, center, 1.12);
   margin-bottom: 12px;
-  letter-spacing: var(--oomol-tracking-section);
-  line-height: 1.12;
-  text-wrap: balance;
 }
 
-.subtitle {
-  font-size: var(--oomol-body-lead);
-  color: var(--oomol-text-secondary);
+.sectionSubtitle {
+  @include marketing-supporting-copy(720px, center);
   max-width: 720px;
   margin: 0 auto;
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
 }
 
 .llmList {

--- a/src/components/HomePagePricing/index.tsx
+++ b/src/components/HomePagePricing/index.tsx
@@ -59,10 +59,10 @@ const pricingTopUpData = [
 const HomepagePricing = () => {
   return (
     <div className={styles.container}>
-      <h1 className={styles.title}>
+      <h2 className={styles.sectionTitle}>
         <img src={"/img/pricing.svg"} />
         {translate({ message: "HOME.Pricing.title" })}
-      </h1>
+      </h2>
       <BlurFade>
         <div className={styles.pricing}>
           {pricingData.map((item, index) => {

--- a/src/components/HomePagePricing/style.module.scss
+++ b/src/components/HomePagePricing/style.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .container {
   display: flex;
   flex-direction: column;
@@ -6,15 +8,11 @@
   box-sizing: border-box;
 }
 
-.title {
+.sectionTitle {
   display: flex;
   align-items: center;
   gap: 14px;
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-font-size-3xl);
-  color: var(--oomol-text-primary);
-  font-weight: 600;
-  letter-spacing: var(--oomol-tracking-section);
+  @include marketing-display-title(section, null, center, 1.12);
   padding-top: 40px;
   padding-bottom: 60px;
 }
@@ -129,7 +127,7 @@
     padding: 0 12px;
   }
 
-  .title {
+  .sectionTitle {
     gap: 10px;
     padding-top: 28px;
     padding-bottom: 36px;

--- a/src/components/HomepageCliEntry/index.tsx
+++ b/src/components/HomepageCliEntry/index.tsx
@@ -67,10 +67,10 @@ export default function HomepageCliEntry() {
           <div className={styles.badge}>
             {translate({ message: "HOME.CliEntry.badge" })}
           </div>
-          <h2 className={styles.title}>
+          <h2 className={styles.sectionTitle}>
             {translate({ message: "HOME.CliEntry.title" })}
           </h2>
-          <p className={styles.subtitle}>
+          <p className={styles.sectionSubtitle}>
             {translate({ message: "HOME.CliEntry.subtitle" })}
           </p>
           <div className={styles.benefitGrid}>

--- a/src/components/HomepageCliEntry/styles.module.scss
+++ b/src/components/HomepageCliEntry/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .section {
   position: relative;
   padding: clamp(3.5rem, 7vw, 5.6rem) 0;
@@ -40,25 +42,12 @@
   }
 }
 
-.title {
-  margin: 0;
-  max-width: 13ch;
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-hero);
-  line-height: 1.04;
-  letter-spacing: var(--oomol-tracking-display);
-  font-weight: 600;
-  text-wrap: balance;
-  color: var(--oomol-text-primary);
+.sectionTitle {
+  @include marketing-display-title(hero, 13ch, left, 1.04);
 }
 
-.subtitle {
-  margin: 0;
-  max-width: 40rem;
-  font-size: var(--oomol-body-lead);
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
-  color: var(--oomol-text-secondary);
+.sectionSubtitle {
+  @include marketing-supporting-copy(40rem);
 }
 
 .benefitGrid {
@@ -376,7 +365,7 @@
     max-width: 100%;
   }
 
-  .title {
+  .sectionTitle {
     max-width: 14ch;
   }
 
@@ -394,7 +383,7 @@
     padding: 0 18px;
   }
 
-  .title {
+  .sectionTitle {
     max-width: 100%;
   }
 
@@ -433,13 +422,13 @@
   }
 }
 
-:global(html[lang="en"]) .title {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 13.5ch;
   font-size: var(--oomol-display-hero);
   line-height: 1.02;
 }
 
-:global(html[lang="en"]) .subtitle {
+:global(html[lang="en"]) .sectionSubtitle {
   max-width: 42rem;
 }
 

--- a/src/components/HomepageCodexBlocks/index.tsx
+++ b/src/components/HomepageCodexBlocks/index.tsx
@@ -32,10 +32,10 @@ export default function HomepageCodexBlocks() {
           <div className={styles.badge}>
             {translate({ message: "HOME.CodexBlocks.badge" })}
           </div>
-          <h2 className={styles.title}>
+          <h2 className={styles.sectionTitle}>
             {translate({ message: "HOME.CodexBlocks.title" })}
           </h2>
-          <p className={styles.subtitle}>
+          <p className={styles.sectionSubtitle}>
             {translate({ message: "HOME.CodexBlocks.subtitle" })}
           </p>
           <div className={styles.headerActions}>

--- a/src/components/HomepageCodexBlocks/styles.module.scss
+++ b/src/components/HomepageCodexBlocks/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .section {
   padding: clamp(4rem, 8vw, 6rem) 0 clamp(2.5rem, 5vw, 4rem);
   background: var(--oomol-bg-base);
@@ -38,25 +40,12 @@
   }
 }
 
-.title {
-  margin: 0;
-  max-width: 12ch;
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-hero);
-  line-height: 1.04;
-  letter-spacing: var(--oomol-tracking-display);
-  font-weight: 600;
-  text-wrap: balance;
-  color: var(--oomol-text-primary);
+.sectionTitle {
+  @include marketing-display-title(hero, 12ch, left, 1.04);
 }
 
-.subtitle {
-  margin: 0;
-  max-width: 48rem;
-  font-size: var(--oomol-body-lead);
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
-  color: var(--oomol-text-secondary);
+.sectionSubtitle {
+  @include marketing-supporting-copy(48rem);
 }
 
 .headerActions {
@@ -262,7 +251,7 @@
   color: var(--oomol-text-secondary);
 }
 
-:global(html[lang="en"]) .title {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 18ch;
   font-size: var(--oomol-display-hero);
   line-height: 1.03;
@@ -283,7 +272,7 @@
     padding: 0 20px;
   }
 
-  .title {
+  .sectionTitle {
     max-width: 100%;
     font-size: var(--oomol-display-hero);
     line-height: 1.08;
@@ -291,7 +280,7 @@
     text-wrap: pretty;
   }
 
-  .subtitle,
+  .sectionSubtitle,
   .cardDescription,
   .videoMetaNote {
     font-size: var(--oomol-body-base);

--- a/src/components/HomepageCommunityShare/index.tsx
+++ b/src/components/HomepageCommunityShare/index.tsx
@@ -38,10 +38,10 @@ export default function HomepageCommunityShare() {
     <section className={styles.section}>
       <div className={styles.container}>
         <div className={styles.content}>
-          <h2 className={styles.title}>
+          <h2 className={styles.sectionTitle}>
             {translate({ id: "HOME.CommunityShare.title" })}
           </h2>
-          <p className={styles.subtitle}>
+          <p className={styles.sectionSubtitle}>
             {translate({ id: "HOME.CommunityShare.subtitle" })}
           </p>
           <div className={styles.pointsGrid}>

--- a/src/components/HomepageCommunityShare/styles.module.scss
+++ b/src/components/HomepageCommunityShare/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .section {
   padding: 0;
 }
@@ -18,25 +20,12 @@
   text-align: left;
 }
 
-.title {
-  margin: 0;
-  max-width: 11ch;
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-hero);
-  line-height: 1.04;
-  letter-spacing: var(--oomol-tracking-display);
-  font-weight: 600;
-  text-wrap: balance;
-  color: var(--oomol-text-primary);
+.sectionTitle {
+  @include marketing-display-title(hero, 11ch, left, 1.04);
 }
 
-.subtitle {
-  margin: 0;
-  max-width: 32rem;
-  font-size: var(--oomol-body-lead);
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
-  color: var(--oomol-text-secondary);
+.sectionSubtitle {
+  @include marketing-supporting-copy(32rem);
 }
 
 .pointsGrid {
@@ -114,7 +103,7 @@
   gap: clamp(2.1rem, 4vw, 3.4rem);
 }
 
-:global(html[lang="en"]) .title {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 18ch;
   font-size: var(--oomol-display-hero);
   line-height: 1.03;
@@ -130,7 +119,7 @@
     gap: 1.5rem;
   }
 
-  .title {
+  .sectionTitle {
     max-width: 100%;
   }
 
@@ -149,7 +138,7 @@
     grid-template-columns: 1fr;
   }
 
-  .title {
+  .sectionTitle {
     font-size: var(--oomol-display-hero);
     line-height: 1.08;
     letter-spacing: var(--oomol-tracking-display);
@@ -160,7 +149,7 @@
     gap: 0.85rem;
   }
 
-  .subtitle,
+  .sectionSubtitle,
   .pointDescription {
     font-size: var(--oomol-body-base);
     line-height: 1.6;

--- a/src/components/HomepageCoreFeatures/styles.module.scss
+++ b/src/components/HomepageCoreFeatures/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .coreFeaturesSection {
   position: relative;
   padding: clamp(4.2rem, 8vw, 6rem) 0;
@@ -18,22 +20,11 @@
 }
 
 .sectionTitle {
-  margin: 0;
-  max-width: 18ch;
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-section);
-  line-height: 1.12;
-  letter-spacing: var(--oomol-tracking-section);
-  color: var(--oomol-text-primary);
+  @include marketing-display-title(section, 18ch, center, 1.12);
 }
 
 .sectionSubtitle {
-  margin: 0;
-  max-width: 46rem;
-  font-size: var(--oomol-body-lead);
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
-  color: var(--oomol-text-secondary);
+  @include marketing-supporting-copy(46rem, center);
 }
 
 .featuresList {

--- a/src/components/HomepageDeveloperBenefits/index.tsx
+++ b/src/components/HomepageDeveloperBenefits/index.tsx
@@ -46,10 +46,10 @@ export default function HomepageDeveloperBenefits() {
           <div className={styles.badge}>
             {translate({ message: "HOME.DeveloperBenefits.badge" })}
           </div>
-          <h2 className={styles.title}>
+          <h2 className={styles.sectionTitle}>
             {translate({ message: "HOME.DeveloperBenefits.title" })}
           </h2>
-          <p className={styles.subtitle}>
+          <p className={styles.sectionSubtitle}>
             {translate({ message: "HOME.DeveloperBenefits.subtitle" })}
           </p>
         </div>

--- a/src/components/HomepageDeveloperBenefits/styles.module.scss
+++ b/src/components/HomepageDeveloperBenefits/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .section {
   padding: clamp(3rem, 6vw, 4.6rem) 0 clamp(2.2rem, 4vw, 3.2rem);
   position: relative;
@@ -54,26 +56,12 @@
   color: var(--oomol-text-tertiary);
 }
 
-.title {
-  margin: 0;
-  max-width: 11ch;
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-hero);
-  line-height: 1.06;
-  letter-spacing: var(--oomol-tracking-display);
-  font-weight: 600;
-  color: var(--oomol-text-primary);
-  text-wrap: balance;
+.sectionTitle {
+  @include marketing-display-title(hero, 11ch, left, 1.06);
 }
 
-.subtitle {
-  margin: 0;
-  max-width: 28rem;
-  font-size: var(--oomol-body-lead);
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
-  text-wrap: pretty;
-  color: var(--oomol-text-secondary);
+.sectionSubtitle {
+  @include marketing-supporting-copy(28rem);
 }
 
 .grid {
@@ -227,13 +215,13 @@
   max-width: 42rem;
 }
 
-:global(html[lang="en"]) .title {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 14ch;
   font-size: var(--oomol-display-hero);
   line-height: 1.02;
 }
 
-:global(html[lang="en"]) .subtitle {
+:global(html[lang="en"]) .sectionSubtitle {
   max-width: 34rem;
 }
 
@@ -270,7 +258,7 @@
     max-width: 100%;
   }
 
-  .title {
+  .sectionTitle {
     max-width: 100%;
   }
 }
@@ -284,7 +272,7 @@
     width: min(100%, calc(100% - 40px));
   }
 
-  .title {
+  .sectionTitle {
     max-width: 100%;
     font-size: var(--oomol-display-hero);
     line-height: 1.1;
@@ -292,7 +280,7 @@
     text-wrap: pretty;
   }
 
-  .subtitle {
+  .sectionSubtitle {
     font-size: var(--oomol-body-base);
     line-height: 1.68;
   }

--- a/src/components/HomepageGuiEntry/index.tsx
+++ b/src/components/HomepageGuiEntry/index.tsx
@@ -86,8 +86,10 @@ export default function HomepageGuiEntry() {
         <div className={styles.card}>
           <div className={styles.copy}>
             <div className={styles.badge}>{copy.badge}</div>
-            <h2 className={styles.title}>{renderLockedBrand(copy.title)}</h2>
-            <p className={styles.description}>{copy.description}</p>
+            <h2 className={styles.sectionTitle}>
+              {renderLockedBrand(copy.title)}
+            </h2>
+            <p className={styles.sectionDescription}>{copy.description}</p>
             <div className={styles.pointRow}>
               {copy.points.map(point => (
                 <span key={point} className={styles.point}>

--- a/src/components/HomepageGuiEntry/styles.module.scss
+++ b/src/components/HomepageGuiEntry/styles.module.scss
@@ -49,7 +49,7 @@
   background: var(--oomol-primary);
 }
 
-.title {
+.sectionTitle {
   @include marketing-display-title(section, 22ch, left, 1.08);
   overflow-wrap: anywhere;
 }
@@ -64,7 +64,7 @@
   }
 }
 
-.description {
+.sectionDescription {
   @include marketing-supporting-copy(34rem);
   overflow-wrap: anywhere;
 }
@@ -126,12 +126,12 @@
     padding-inline: 20px;
   }
 
-  .title {
+  .sectionTitle {
     max-width: 100%;
     font-size: var(--oomol-display-section);
   }
 
-  .description {
+  .sectionDescription {
     @include marketing-mobile-supporting-copy();
   }
 
@@ -151,7 +151,7 @@
     padding-inline: 16px;
   }
 
-  .title {
+  .sectionTitle {
     font-size: var(--oomol-display-card);
     line-height: 1.14;
   }

--- a/src/components/HomepageLifecycle/styles.module.scss
+++ b/src/components/HomepageLifecycle/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .lifecycleSection {
   padding: 120px 0;
   background: var(--ifm-background-color);
@@ -19,23 +21,14 @@
 }
 
 .sectionTitle {
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-section);
-  font-weight: 600;
-  color: var(--oomol-text-primary);
+  @include marketing-display-title(section, null, center, 1.12);
   margin-bottom: 16px;
-  letter-spacing: var(--oomol-tracking-section);
-  line-height: 1.12;
-  text-wrap: balance;
 }
 
 .sectionSubtitle {
-  font-size: var(--oomol-body-lead);
-  color: var(--oomol-text-secondary);
+  @include marketing-supporting-copy(720px, center);
   max-width: 720px;
   margin: 0 auto;
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
 }
 
 // 主内容区 - 左右分栏

--- a/src/components/HomepageLinearFlow/styles.module.scss
+++ b/src/components/HomepageLinearFlow/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .flow {
   display: grid;
   gap: 0;
@@ -74,25 +76,13 @@
 }
 
 .sectionTitle {
-  margin: 0;
-  max-width: 18ch;
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-hero);
-  line-height: 1.08;
-  letter-spacing: var(--oomol-tracking-display);
-  font-weight: 600;
-  color: var(--oomol-text-primary);
+  @include marketing-display-title(hero, 18ch, left, 1.08);
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
 .sectionDescription {
-  margin: 0;
-  max-width: 36rem;
-  font-size: var(--oomol-body-lead);
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
-  color: var(--oomol-text-secondary);
+  @include marketing-supporting-copy(36rem);
   overflow-wrap: anywhere;
   word-break: break-word;
 }
@@ -266,8 +256,7 @@
   }
 
   .sectionDescription {
-    font-size: var(--oomol-body-base);
-    line-height: 1.6;
+    @include marketing-mobile-supporting-copy();
   }
 
   .inlineActions {

--- a/src/components/HomepagePainPoints/index.tsx
+++ b/src/components/HomepagePainPoints/index.tsx
@@ -116,8 +116,8 @@ export default function HomepagePainPoints() {
       <div className={styles.container}>
         <div className={styles.header}>
           <div className={styles.badge}>{copy.badge}</div>
-          <h2 className={styles.title}>{copy.title}</h2>
-          <p className={styles.subtitle}>{copy.subtitle}</p>
+          <h2 className={styles.sectionTitle}>{copy.title}</h2>
+          <p className={styles.sectionSubtitle}>{copy.subtitle}</p>
         </div>
 
         <div className={styles.grid}>

--- a/src/components/HomepagePainPoints/styles.module.scss
+++ b/src/components/HomepagePainPoints/styles.module.scss
@@ -47,11 +47,11 @@
   }
 }
 
-.title {
+.sectionTitle {
   @include marketing-display-title(hero, 22ch, left, 1.06);
 }
 
-.subtitle {
+.sectionSubtitle {
   @include marketing-supporting-copy(40rem);
 }
 
@@ -255,16 +255,16 @@
 
 /* ── English overrides ── */
 
-:global(html[lang="en"]) .title {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 26ch;
   font-size: var(--oomol-display-hero);
 }
 
-:global(html[lang="zh-CN"]) .title {
+:global(html[lang="zh-CN"]) .sectionTitle {
   max-width: 17ch;
 }
 
-:global(html[lang="en"]) .subtitle {
+:global(html[lang="en"]) .sectionSubtitle {
   max-width: 48rem;
 }
 
@@ -293,14 +293,14 @@
     gap: 0.7rem;
   }
 
-  .title {
+  .sectionTitle {
     max-width: 100%;
     font-size: var(--oomol-display-hero);
     line-height: 1.08;
     letter-spacing: var(--oomol-tracking-display);
   }
 
-  .subtitle {
+  .sectionSubtitle {
     @include marketing-mobile-supporting-copy();
     max-width: 32rem;
   }

--- a/src/components/HomepagePdfCraftShowcase/index.tsx
+++ b/src/components/HomepagePdfCraftShowcase/index.tsx
@@ -9,10 +9,10 @@ export default function HomepagePdfCraftShowcase() {
     <section id="pdf-craft-case" className={styles.section}>
       <div className={styles.container}>
         <div className={styles.header}>
-          <h2 className={styles.title}>
+          <h2 className={styles.sectionTitle}>
             {translate({ message: "HOME.PdfCraft.title" })}
           </h2>
-          <p className={styles.subtitle}>
+          <p className={styles.sectionSubtitle}>
             {translate({ message: "HOME.PdfCraft.subtitle" })}
           </p>
         </div>

--- a/src/components/HomepagePdfCraftShowcase/styles.module.scss
+++ b/src/components/HomepagePdfCraftShowcase/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .section {
   position: relative;
   padding: 120px 24px;
@@ -22,15 +24,9 @@
   }
 }
 
-.title {
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-section);
-  font-weight: 600;
-  color: var(--oomol-text-primary);
+.sectionTitle {
+  @include marketing-display-title(section, null, center, 1.12);
   margin-bottom: 12px;
-  letter-spacing: var(--oomol-tracking-section);
-  line-height: 1.12;
-  text-wrap: balance;
 
   @media (max-width: 996px) {
     font-size: var(--oomol-display-section);
@@ -41,13 +37,10 @@
   }
 }
 
-.subtitle {
-  font-size: var(--oomol-body-lead);
-  color: var(--oomol-text-secondary);
+.sectionSubtitle {
+  @include marketing-supporting-copy(720px, center);
   max-width: 720px;
   margin: 0 auto;
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
 }
 
 .content {

--- a/src/components/HomepageProductComparison/styles.module.scss
+++ b/src/components/HomepageProductComparison/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .comparisonSection {
   padding: clamp(4rem, 8vw, 6rem) 0;
   background: var(--oomol-bg-base);
@@ -26,24 +28,11 @@
 }
 
 .sectionTitle {
-  margin: 0;
-  max-width: 13ch;
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-hero);
-  line-height: 1.04;
-  letter-spacing: var(--oomol-tracking-display);
-  font-weight: 600;
-  text-wrap: balance;
-  color: var(--oomol-text-primary);
+  @include marketing-display-title(hero, 13ch, left, 1.04);
 }
 
 .sectionSubtitle {
-  margin: 0;
-  max-width: 48rem;
-  font-size: var(--oomol-body-lead);
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
-  color: var(--oomol-text-secondary);
+  @include marketing-supporting-copy(48rem);
 }
 
 .headerRule {

--- a/src/components/HomepageStarter/index.tsx
+++ b/src/components/HomepageStarter/index.tsx
@@ -24,11 +24,11 @@ export default function HomepageStarter() {
   return (
     <div className={styles.sectionStarter}>
       <img src={logoSrc} alt="logo" />
-      <div className={styles.title}>Start creating today</div>
-      <div className={styles.inner}>
+      <h2 className={styles.sectionTitle}>Start creating today</h2>
+      <p className={styles.sectionDescription}>
         Whether you’re new to Oomol or back to see what’s new, we’ll have you
         set up and ready to do your best work in minutes.
-      </div>
+      </p>
       <Button asChild size="lg" className={styles.cta}>
         <Link to="/downloads">Download</Link>
       </Button>

--- a/src/components/HomepageStarter/styles.module.scss
+++ b/src/components/HomepageStarter/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .sectionStarter {
   width: 100%;
   display: flex;
@@ -11,20 +13,15 @@
   box-sizing: border-box;
 }
 
-.title {
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-section);
-  line-height: 1.12;
-  letter-spacing: var(--oomol-tracking-section);
-  font-weight: 600;
+.sectionTitle {
+  @include marketing-display-title(section, null, center, 1.12);
   margin-top: 12px;
   margin-bottom: 12px;
-  color: var(--oomol-text-primary);
-  text-wrap: balance;
 }
 
-.inner {
+.sectionDescription {
   width: min(600px, 100%);
+  @include marketing-supporting-copy(600px, center);
   text-align: center;
   margin-bottom: 48px;
 }
@@ -42,7 +39,7 @@
     padding-right: 12px;
   }
 
-  .inner {
+  .sectionDescription {
     width: 100%;
     padding: 0;
     margin-bottom: 28px;

--- a/src/components/HomepageToolStrip/index.tsx
+++ b/src/components/HomepageToolStrip/index.tsx
@@ -111,8 +111,8 @@ export default function HomepageToolStrip() {
     <section className={styles.section}>
       <div className={styles.container}>
         <div className={styles.copyColumn}>
-          <h2 className={styles.title}>{copy.title}</h2>
-          <p className={styles.description}>{copy.description}</p>
+          <h2 className={styles.sectionTitle}>{copy.title}</h2>
+          <p className={styles.sectionDescription}>{copy.description}</p>
         </div>
 
         <div className={styles.surfacePanel}>

--- a/src/components/HomepageToolStrip/styles.module.scss
+++ b/src/components/HomepageToolStrip/styles.module.scss
@@ -22,7 +22,7 @@
   max-width: 30rem;
 }
 
-.title {
+.sectionTitle {
   @include marketing-display-title(section, 18ch, left, 1.08);
 }
 
@@ -36,7 +36,7 @@
   backdrop-filter: none;
 }
 
-.description {
+.sectionDescription {
   @include marketing-supporting-copy();
 }
 
@@ -161,12 +161,12 @@
   letter-spacing: -0.003em;
 }
 
-:global(html[lang="en"]) .title {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 22ch;
   font-size: var(--oomol-display-section);
 }
 
-:global(html[lang="en"]) .description {
+:global(html[lang="en"]) .sectionDescription {
   max-width: 40rem;
 }
 
@@ -180,7 +180,7 @@
     max-width: 100%;
   }
 
-  .title {
+  .sectionTitle {
     max-width: 100%;
   }
 }
@@ -194,7 +194,7 @@
     width: min(100%, calc(100% - 40px));
   }
 
-  .description {
+  .sectionDescription {
     @include marketing-mobile-supporting-copy();
   }
 

--- a/src/components/HomepageWhyOomol/index.tsx
+++ b/src/components/HomepageWhyOomol/index.tsx
@@ -86,8 +86,8 @@ export default function HomepageWhyOomol() {
       <div className={styles.container}>
         <div className={styles.header}>
           <div className={styles.badge}>{copy.badge}</div>
-          <h2 className={styles.title}>{copy.title}</h2>
-          <p className={styles.subtitle}>{copy.subtitle}</p>
+          <h2 className={styles.sectionTitle}>{copy.title}</h2>
+          <p className={styles.sectionSubtitle}>{copy.subtitle}</p>
           <div className={styles.actions}>
             <Button asChild size="sm" className={styles.primaryAction}>
               <Link to="/studio">{copy.primaryCta}</Link>

--- a/src/components/HomepageWhyOomol/styles.module.scss
+++ b/src/components/HomepageWhyOomol/styles.module.scss
@@ -46,11 +46,11 @@
   }
 }
 
-.title {
+.sectionTitle {
   @include marketing-display-title(hero, 24ch, left, 1.06);
 }
 
-.subtitle {
+.sectionSubtitle {
   @include marketing-supporting-copy(46rem);
 }
 
@@ -140,17 +140,17 @@
   color: var(--oomol-text-secondary);
 }
 
-:global(html[lang="en"]) .title {
+:global(html[lang="en"]) .sectionTitle {
   max-width: 24ch;
   font-size: var(--oomol-display-hero);
   line-height: 1.06;
 }
 
-:global(html[lang="en"]) .subtitle {
+:global(html[lang="en"]) .sectionSubtitle {
   max-width: 46rem;
 }
 
-:global(html[lang="zh-CN"]) .title {
+:global(html[lang="zh-CN"]) .sectionTitle {
   max-width: 18ch;
 }
 
@@ -188,12 +188,12 @@
     gap: 2rem;
   }
 
-  .title {
+  .sectionTitle {
     max-width: 100%;
     font-size: var(--oomol-display-hero);
   }
 
-  .subtitle,
+  .sectionSubtitle,
   .cardText {
     @include marketing-mobile-supporting-copy();
   }

--- a/src/components/SiteCta/index.tsx
+++ b/src/components/SiteCta/index.tsx
@@ -21,8 +21,8 @@ export function SiteCta({
   return (
     <section id={id} className={clsx(styles.section, className)}>
       <div className={styles.inner}>
-        <h2 className={styles.title}>{title}</h2>
-        <p className={styles.description}>{description}</p>
+        <h2 className={styles.ctaTitle}>{title}</h2>
+        <p className={styles.ctaDescription}>{description}</p>
         <div className={styles.actions}>{actions}</div>
       </div>
     </section>

--- a/src/components/SiteCta/styles.module.scss
+++ b/src/components/SiteCta/styles.module.scss
@@ -28,13 +28,13 @@
   text-align: center;
 }
 
-.title {
+.ctaTitle {
   @include marketing-display-title(section, 24ch, center, 1.08);
   overflow-wrap: anywhere;
   word-break: break-word;
 }
 
-.description {
+.ctaDescription {
   @include marketing-supporting-copy(42rem, center);
   overflow-wrap: anywhere;
   word-break: break-word;
@@ -84,12 +84,12 @@
     padding-bottom: 2rem;
   }
 
-  .title {
+  .ctaTitle {
     max-width: 100%;
     font-size: var(--oomol-display-section);
   }
 
-  .description {
+  .ctaDescription {
     @include marketing-mobile-supporting-copy();
   }
 
@@ -117,7 +117,7 @@
     padding-bottom: 1.65rem;
   }
 
-  .title {
+  .ctaTitle {
     font-size: var(--oomol-display-card);
     line-height: 1.14;
   }

--- a/src/components/SiteCta/styles.module.scss
+++ b/src/components/SiteCta/styles.module.scss
@@ -4,8 +4,7 @@
   width: 100%;
   /* Horizontal padding is on `.section` (not `.inner`) so the rounded
      `.inner` card never touches the viewport edge on narrow screens. */
-  padding:
-    clamp(5rem, 10vw, 8rem) clamp(16px, 4vw, 32px)
+  padding: clamp(5rem, 10vw, 8rem) clamp(16px, 4vw, 32px)
     clamp(3.5rem, 7vw, 5.5rem);
   background: var(--oomol-bg-spotlight);
   box-sizing: border-box;

--- a/src/components/StudioDetailContent/index.tsx
+++ b/src/components/StudioDetailContent/index.tsx
@@ -172,10 +172,10 @@ export default function StudioDetailContent({
   return (
     <div className={styles.container}>
       <header className={styles.manifestHeader}>
-        <h1 className={styles.title}>
+        <h1 className={styles.heroTitle}>
           {translate({ message: "STUDIO.manifesto.title" })}
         </h1>
-        <p className={styles.subtitle}>
+        <p className={styles.heroSubtitle}>
           {translate({ message: "STUDIO.manifesto.subtitle" })}
         </p>
       </header>

--- a/src/components/StudioDetailContent/styles.module.scss
+++ b/src/components/StudioDetailContent/styles.module.scss
@@ -426,7 +426,7 @@
   }
 }
 
-.title {
+.heroTitle {
   font-family: var(--oomol-font-display);
   font-size: var(--oomol-display-hero);
   font-weight: 600;
@@ -441,7 +441,7 @@
   }
 }
 
-.subtitle {
+.heroSubtitle {
   font-size: var(--oomol-body-lead);
   color: var(--oomol-text-secondary);
   font-weight: 400;

--- a/src/components/StudioPdfCraftCase/index.tsx
+++ b/src/components/StudioPdfCraftCase/index.tsx
@@ -8,10 +8,10 @@ export default function StudioPdfCraftCase() {
     <section className={styles.section}>
       <div className={styles.container}>
         <div className={styles.header}>
-          <h2 className={styles.title}>
+          <h2 className={styles.sectionTitle}>
             {translate({ message: "STUDIO.case.title" })}
           </h2>
-          <p className={styles.subtitle}>
+          <p className={styles.sectionSubtitle}>
             {translate({ message: "STUDIO.case.subtitle" })}
           </p>
         </div>

--- a/src/components/StudioPdfCraftCase/styles.module.scss
+++ b/src/components/StudioPdfCraftCase/styles.module.scss
@@ -1,3 +1,5 @@
+@use "../../css/mixins.scss" as *;
+
 .section {
   padding: 100px 24px;
   background: var(--oomol-bg-base);
@@ -21,28 +23,19 @@
   }
 }
 
-.title {
-  font-family: var(--oomol-font-display);
-  font-size: var(--oomol-display-section);
-  font-weight: 600;
-  letter-spacing: var(--oomol-tracking-section);
-  line-height: 1.12;
+.sectionTitle {
+  @include marketing-display-title(section, null, center, 1.12);
   margin-bottom: 16px;
-  color: var(--oomol-text-primary);
-  text-wrap: balance;
 
   @media (max-width: 768px) {
     font-size: var(--oomol-display-section);
   }
 }
 
-.subtitle {
-  font-size: var(--oomol-body-lead);
-  color: var(--oomol-text-secondary);
+.sectionSubtitle {
+  @include marketing-supporting-copy(700px, center);
   max-width: 700px;
   margin: 0 auto;
-  line-height: var(--oomol-line-height-relaxed);
-  letter-spacing: var(--oomol-tracking-body);
 
   @media (max-width: 768px) {
     font-size: var(--oomol-body-lead);

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -297,9 +297,8 @@ body,
 /* Lead / section-intro copy: treat these as subtitle-grade copy, not generic body text.
    This prevents app/landing intro paragraphs from being pulled back to the zh body 1.72 line-height. */
 .oomol-home-main [class*="lead" i]:not([class*="card" i]),
-.oomol-landing-main:not(.oomol-app-page) [class*="lead" i]:not(
-    [class*="card" i]
-  ),
+.oomol-landing-main:not(.oomol-app-page)
+  [class*="lead" i]:not([class*="card" i]),
 .oomol-home-main [class*="sectionIntro" i] > p,
 .oomol-landing-main:not(.oomol-app-page) [class*="sectionIntro" i] > p {
   font-size: var(--oomol-body-lead);

--- a/src/pages/brand-assets/index.tsx
+++ b/src/pages/brand-assets/index.tsx
@@ -215,10 +215,10 @@ export default function BrandAssets() {
       </Head>
       <div className={styles.container}>
         <div className={styles.titleBox}>
-          <h1 className={styles.title}>
+          <h1 className={styles.heroTitle}>
             {translate({ message: "HOME.BrandAssets.title" })}
           </h1>
-          <p className={styles.subTitle}>
+          <p className={styles.heroSubtitle}>
             {translate({ message: "HOME.BrandAssets.subtitle" })}
           </p>
         </div>

--- a/src/pages/brand-assets/styles.module.scss
+++ b/src/pages/brand-assets/styles.module.scss
@@ -23,14 +23,14 @@
   position: relative;
 }
 
-.title {
+.heroTitle {
   display: flex;
   align-items: center;
   justify-content: center;
   @include marketing-display-title(hero, 22ch, center, 1.06);
 }
 
-.subTitle {
+.heroSubtitle {
   @include marketing-supporting-copy(42rem, center);
   font-weight: 400;
   @include flatSecondaryText;
@@ -218,7 +218,7 @@
     max-width: 100%;
   }
 
-  .subTitle {
+  .heroSubtitle {
     max-width: 100%;
     @include marketing-mobile-supporting-copy();
   }

--- a/src/pages/contact-us/index.tsx
+++ b/src/pages/contact-us/index.tsx
@@ -259,12 +259,12 @@ export default function ContactUsPage() {
       <div className={styles.container}>
         <div className={styles.headBox}>
           <div className={styles.titleBox}>
-            <h1 className={styles.title}>
+            <h1 className={styles.heroTitle}>
               {translate({
                 message: "HOME.Community.title",
               })}
             </h1>
-            <p className={styles.subTitle}>
+            <p className={styles.sectionSubtitle}>
               {translate({
                 message: "HOME.Community.subtitle",
               })}
@@ -325,7 +325,7 @@ export default function ContactUsPage() {
               message: "HOME.Community.open-source.title",
             })}
           </h2>
-          <p className={styles.subTitle}>
+          <p className={styles.sectionSubtitle}>
             {translate({
               message: "HOME.Community.open-source.subtitle",
             })}

--- a/src/pages/contact-us/styles.module.scss
+++ b/src/pages/contact-us/styles.module.scss
@@ -36,7 +36,7 @@
   margin: 0 auto;
 }
 
-.title {
+.heroTitle {
   @include marketing-display-title(hero, 22ch, center, 1.06);
 }
 
@@ -44,7 +44,7 @@
   @include marketing-display-title(section, 22ch, center, 1.08);
 }
 
-.subTitle {
+.sectionSubtitle {
   @include marketing-supporting-copy(42rem, center);
   font-weight: 400;
   @include flatSecondaryText;
@@ -326,7 +326,7 @@
     max-width: 100%;
   }
 
-  .subTitle {
+  .sectionSubtitle {
     @include marketing-mobile-supporting-copy();
   }
 
@@ -375,7 +375,7 @@
     gap: 22px;
   }
 
-  .title {
+  .heroTitle {
     font-size: clamp(2.3rem, 12vw, 3.1rem);
     line-height: 1.08;
   }
@@ -385,7 +385,7 @@
     font-size: var(--oomol-display-section);
   }
 
-  .subTitle {
+  .sectionSubtitle {
     @include marketing-mobile-supporting-copy();
   }
 

--- a/src/pages/downloads/index.tsx
+++ b/src/pages/downloads/index.tsx
@@ -171,8 +171,8 @@ export default function Downloads() {
           <div className={styles.heroInner}>
             <span className={styles.eyebrow}>{copy.heroEyebrow}</span>
             <div className={styles.titleBox}>
-              <h1 className={styles.title}>{copy.heroTitle}</h1>
-              <p className={styles["sub-title"]}>{copy.heroSubtitle}</p>
+              <h1 className={styles.heroTitle}>{copy.heroTitle}</h1>
+              <p className={styles.heroSubtitle}>{copy.heroSubtitle}</p>
             </div>
           </div>
         </section>

--- a/src/pages/downloads/styles.module.scss
+++ b/src/pages/downloads/styles.module.scss
@@ -55,12 +55,12 @@
   margin-inline: auto;
 }
 
-.title {
+.heroTitle {
   @include marketing-display-title(hero, 18.5ch, center, 1.05);
   margin-inline: auto;
 }
 
-.sub-title {
+.heroSubtitle {
   @include marketing-supporting-copy(48rem, center);
   margin-inline: auto;
 }
@@ -309,13 +309,13 @@
     padding: clamp(2.6rem, 7vw, 3.4rem) 0 clamp(1.6rem, 4vw, 2.2rem);
   }
 
-  .title {
+  .heroTitle {
     max-width: 100%;
     font-size: var(--oomol-display-hero);
     line-height: 1.08;
   }
 
-  .sub-title {
+  .heroSubtitle {
     @include marketing-mobile-supporting-copy();
   }
 
@@ -371,12 +371,12 @@
     gap: 0.65rem;
   }
 
-  .title {
+  .heroTitle {
     font-size: clamp(2.25rem, 12vw, 3rem);
     line-height: 1.06;
   }
 
-  .sub-title,
+  .heroSubtitle,
   .sectionSubtitle {
     line-height: 1.56;
   }

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -667,10 +667,10 @@ export default function Index() {
         <section className={styles.heroSection}>
           <div className={styles.sectionInner}>
             <div className={styles.titleBox}>
-              <h1 className={styles.title}>
+              <h1 className={styles.heroTitle}>
                 {translate({ message: "PRICING.title" })}
               </h1>
-              <p className={styles.subTitle}>
+              <p className={styles.heroSubtitle}>
                 {translate({ message: "PRICING.subtitle" })}
               </p>
             </div>

--- a/src/pages/pricing/styles.module.scss
+++ b/src/pages/pricing/styles.module.scss
@@ -49,11 +49,11 @@
   text-align: center;
 }
 
-.title {
+.heroTitle {
   @include marketing-display-title(hero, 20ch, center, 1.04);
 }
 
-.subTitle {
+.heroSubtitle {
   @include marketing-supporting-copy(40rem, center);
   font-weight: 400;
 }
@@ -618,12 +618,12 @@
     isolation: isolate;
   }
 
-  .title {
+  .heroTitle {
     color: var(--oomol-text-primary);
     text-shadow: none;
   }
 
-  .subTitle {
+  .heroSubtitle {
     color: var(--oomol-text-secondary);
   }
 
@@ -857,12 +857,12 @@
     gap: 0.9rem;
   }
 
-  .title {
+  .heroTitle {
     max-width: 100%;
     text-wrap: pretty;
   }
 
-  .subTitle {
+  .heroSubtitle {
     max-width: 100%;
     font-size: var(--oomol-body-base);
     line-height: 1.62;

--- a/src/pages/support/index.tsx
+++ b/src/pages/support/index.tsx
@@ -27,7 +27,7 @@ export default function Support() {
         <div className={styles.supportCellBox}>
           <Card className={styles.supportCell}>
             <CardHeader className={styles.supportHeader}>
-              <div className={styles.title}>
+              <div className={styles.supportCardTitleRow}>
                 <i
                   className={`i-bi-github ${styles.titleIcon}`}
                   aria-hidden="true"
@@ -55,7 +55,7 @@ export default function Support() {
           </Card>
           <Card className={styles.supportCell}>
             <CardHeader className={styles.supportHeader}>
-              <div className={styles.title}>
+              <div className={styles.supportCardTitleRow}>
                 <i
                   className={`i-bi-discord ${styles.titleIconMuted}`}
                   aria-hidden="true"
@@ -83,7 +83,7 @@ export default function Support() {
           </Card>
           <Card className={styles.supportCell}>
             <CardHeader className={styles.supportHeader}>
-              <div className={styles.title}>
+              <div className={styles.supportCardTitleRow}>
                 <i
                   className={`i-codicon-mail ${styles.titleIcon}`}
                   aria-hidden="true"

--- a/src/pages/support/styles.module.scss
+++ b/src/pages/support/styles.module.scss
@@ -55,7 +55,7 @@
   padding-bottom: 8px;
 }
 
-.title {
+.supportCardTitleRow {
   width: 100%;
   font-weight: 600;
   font-size: var(--oomol-font-size-lg);

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -208,7 +208,7 @@ const Footer: React.FC = () => {
           {links.map((linkItem, i) => (
             <div key={i} className={styles.category}>
               {linkItem.title && (
-                <div className={styles.title}>{linkItem.title}</div>
+                <div className={styles.categoryTitle}>{linkItem.title}</div>
               )}
               {linkItem.items?.length > 0 && (
                 <div className={styles.items}>

--- a/src/theme/Footer/styles.module.scss
+++ b/src/theme/Footer/styles.module.scss
@@ -53,7 +53,7 @@
   gap: 0.1rem;
 }
 
-.title {
+.categoryTitle {
   margin: 0;
   font-family: var(--oomol-font-display);
   font-size: var(--oomol-font-size-sm);


### PR DESCRIPTION
## What changed
- refactored marketing and landing page components to use more specific typography class names such as `sectionTitle`, `sectionSubtitle`, `heroTitle`, and `categoryTitle`
- replaced repeated title/subtitle typography declarations with shared marketing mixins in the updated SCSS modules
- fixed Prettier formatting in `src/components/SiteCta/styles.module.scss` and `src/css/custom.scss` so the repository lint check passes cleanly

## Why
Several components were using generic class names like `title`, `subtitle`, and `description` across CSS modules. This cleanup makes the naming more explicit and keeps the typography rules aligned through shared mixins, while also removing formatting issues that blocked lint.

## Impact
- clearer, more maintainable naming across the marketing pages
- less duplicated typography styling in SCSS modules
- green `npm run lint` on this branch

## Validation
- `npm run lint`
