### PR TITLE
[codex] Align CTA, navigation, and blog media previews

### DIFF
--- a/blog/2025-06-24-OOMOL-vs-Zapier-vs-n8n/index.mdx
+++ b/blog/2025-06-24-OOMOL-vs-Zapier-vs-n8n/index.mdx
@@ -4,6 +4,7 @@ title: OOMOL Studio vs Zapier vs n8n
 authors: [zhangli]
 tags: [zapier, oomol, n8n, coding]
 date: 2025-06-24
+description: "OOMOL Studio approaches workflow automation from a different angle, combining local containers and full code support with the flexibility users miss in Zapier and n8n."
 ---
 
 import Image from "@theme/ThemedImage";

--- a/blog/2025-06-25-Future-Trends-of-Automated-Workflows/index.mdx
+++ b/blog/2025-06-25-Future-Trends-of-Automated-Workflows/index.mdx
@@ -3,6 +3,7 @@ title: Why is OOMOL Studio at the forefront of automated workflow development?
 authors: [zhangli]
 tags: [workflow automation, n8n, Zapier]
 date: 2025-06-25
+description: "OOMOL Studio extends automated workflow tools with full code environments, local execution, image export, and a more complete developer experience."
 ---
 
 <Image

--- a/blog/2025-07-14-AI-translation-produces-bilingual-EPUB-e-books/index.mdx
+++ b/blog/2025-07-14-AI-translation-produces-bilingual-EPUB-e-books/index.mdx
@@ -9,16 +9,18 @@ import Image from "@theme/ThemedImage";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import ResponsiveVideoEmbed from "@site/src/components/mdx/ResponsiveVideoEmbed";
 
+Are you tired of the bad experience of messy formatting and no layout after e-book translation? EPUB Translator's intelligent translation technology not only perfectly preserves the exquisite layout of the original book, but also has a unique bilingual comparison function, making language learning more intuitive and efficient than ever before.
+
+Whether reading original novels or studying professional literature, you can now get precisely aligned bilingual texts, with all illustrations, chapters and special formats fully preserved. The original sentence and the translation are presented side by side, helping you to easily compare and learn, just like having a translation mentor at your side at any time, making cross-language reading a truly pleasant learning journey.
+
+<!-- truncate -->
+
 <ResponsiveVideoEmbed
   src="https://www.youtube.com/embed/QsAdiskxfXI?si=v8UTDAf8ZP9x_XXb"
   title="AI translation to create bilingual EPUB e-books video"
   referrerPolicy="strict-origin-when-cross-origin"
   scrolling="no"
 />
-
-Are you tired of the bad experience of messy formatting and no layout after e-book translation? EPUB Translator's intelligent translation technology not only perfectly preserves the exquisite layout of the original book, but also has a unique bilingual comparison function, making language learning more intuitive and efficient than ever before.
-
-Whether reading original novels or studying professional literature, you can now get precisely aligned bilingual texts, with all illustrations, chapters and special formats fully preserved. The original sentence and the translation are presented side by side, helping you to easily compare and learn, just like having a translation mentor at your side at any time, making cross-language reading a truly pleasant learning journey.
 
 <figure>
   <Image

--- a/blog/2025-07-14-Convert-scanned-PDF-books-to-EPUB/index.mdx
+++ b/blog/2025-07-14-Convert-scanned-PDF-books-to-EPUB/index.mdx
@@ -9,12 +9,6 @@ import Image from "@theme/ThemedImage";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import ResponsiveVideoEmbed from "@site/src/components/mdx/ResponsiveVideoEmbed";
 
-<ResponsiveVideoEmbed
-  src="https://www.youtube.com/embed/1yYBCVry77I?si=EfPneR7SHgrZ4J7Y"
-  title="PDF Craft: Convert scanned PDF books to EPUB video"
-  referrerPolicy="strict-origin-when-cross-origin"
-/>
-
 Do you also collect a lot of scanned PDF documents? Those academic papers, e-books or work materials, although the content is precious, are very difficult to read - rigid layout, unadjustable fonts, always need to zoom in and out when reading on mobile phones.
 
 Now, these PDFs can be easily converted into comfortable EPUB format through pdf-craft. Just like organizing a pile of paper documents into a portable e-book, you can finally browse these contents in the most suitable way for you on your favorite EPUB reader: adjust the font size, switch to night mode, or even listen to AI reading.
@@ -22,6 +16,14 @@ Now, these PDFs can be easily converted into comfortable EPUB format through pdf
 [pdf-craft](https://github.com/oomol-lab/pdf-craft) is an open source library dedicated to processing scanned book PDFs. It can accurately identify text content, headers and footers, reference annotations, etc. in PDF files. It can maintain the coherence of cross-page content and restore the correct reading order. In addition, it will use LLM to build a complete EPUB contents structure.
 
 It is very simple to use pdf-craft in oomol. First, create a blank project. Then type "pdf-craft" in the search box in the [oomol store](https://hub.oomol.com/package/pdf-craft) to find it.
+
+<!-- truncate -->
+
+<ResponsiveVideoEmbed
+  src="https://www.youtube.com/embed/1yYBCVry77I?si=EfPneR7SHgrZ4J7Y"
+  title="PDF Craft: Convert scanned PDF books to EPUB video"
+  referrerPolicy="strict-origin-when-cross-origin"
+/>
 
 
 <figure>

--- a/blog/2025-07-14-write-code-INSIDE-your-workflow/index.mdx
+++ b/blog/2025-07-14-write-code-INSIDE-your-workflow/index.mdx
@@ -19,6 +19,8 @@ The process of writing code is as smooth as in a familiar IDE. You can use Pytho
 
 In the video, I fully demonstrate how to quickly build a custom image processing pipeline with code slots.
 
+<!-- truncate -->
+
 <ResponsiveVideoEmbed
   src="https://www.youtube.com/embed/kFwiMYky9Pg?si=RfSwAv5JeOK5Ygm6"
   title="Write Code INSIDE Your Workflow video"

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -248,24 +248,31 @@ const config = {
             className: "productDropdown",
             items: [
               {
-                to: "/docs/oo-cli",
+                to: "/cli",
                 label: "navbar.oo-cli",
                 className: "productDropdownItem productDropdownItemCli",
+                activeBaseRegex:
+                  "^/(?:zh-CN/)?(?:cli(?:/.*)?|docs/oo-cli(?:/.*)?|docs/cloud-services/cli(?:/.*)?|docs/cloud-services/cli-command-reference(?:/.*)?)$",
               },
               {
                 to: "/studio",
                 label: "navbar.oomol-studio",
                 className: "productDropdownItem productDropdownItemStudio",
+                activeBaseRegex:
+                  "^/(?:zh-CN/)?(?:studio(?:/.*)?|docs/(?:concepts|get-started|advanced-guide|workflow-engine)(?:/.*)?)$",
               },
               {
                 to: "/cloud",
                 label: "navbar.oomol-cloud",
                 className: "productDropdownItem productDropdownItemCloud",
+                activeBaseRegex:
+                  "^/(?:zh-CN/)?(?:cloud(?:/.*)?|docs/cloud-services/cloud-function(?:/.*)?|docs/cloud-services/cloud-task(?:/.*)?)$",
               },
               {
                 to: "/app",
                 label: "navbar.oomol-ai",
                 className: "productDropdownItem productDropdownItemAi",
+                activeBaseRegex: "^/(?:zh-CN/)?app(?:/.*)?$",
               },
             ],
           },

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -29,7 +29,7 @@
   },
   "link.item.label.Documentation": {
     "message": "Documentation",
-    "description": "The label of footer link with label=Documentation linking to /docs/introduction/overview"
+    "description": "The label of footer link with label=Documentation linking to /docs/overview"
   },
   "link.item.label.Updates": {
     "message": "Changelog",

--- a/i18n/zh-CN/docusaurus-plugin-content-blog/2025-06-24-OOMOL-vs-Zapier-vs-n8n/index.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-blog/2025-06-24-OOMOL-vs-Zapier-vs-n8n/index.mdx
@@ -4,6 +4,7 @@ title: OOMOL Studio vs Zapier vs n8n
 authors: [zhangli]
 tags: [zapier, oomol, n8n, coding]
 date: 2025-06-24
+description: "OOMOL Studio 从不同角度切入工作流自动化，把本地容器和完整代码支持带进了 Zapier 与 n8n 难以覆盖的自由度里。"
 ---
 
 import Image from "@theme/ThemedImage";

--- a/i18n/zh-CN/docusaurus-plugin-content-blog/2025-06-25-Future-Trends-of-Automated-Workflows/index.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-blog/2025-06-25-Future-Trends-of-Automated-Workflows/index.mdx
@@ -3,6 +3,7 @@ title: 为什么 OOMOL Studio 处于自动化工作流程开发的前沿？
 authors: [zhangli]
 tags: [workflow automation, n8n, Zapier]
 date: 2025-06-25
+description: "OOMOL Studio 通过完整代码环境、本地运行、镜像导出和更完善的开发者体验，把自动化工作流工具继续往前推进了一步。"
 ---
 
 import Image from "@theme/ThemedImage";

--- a/i18n/zh-CN/docusaurus-plugin-content-blog/2025-07-14-AI-translation-produces-bilingual-EPUB-e-books/index.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-blog/2025-07-14-AI-translation-produces-bilingual-EPUB-e-books/index.mdx
@@ -9,15 +9,17 @@ import Image from "@theme/ThemedImage";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import ResponsiveVideoEmbed from "@site/src/components/mdx/ResponsiveVideoEmbed";
 
+是否厌倦了电子书翻译后格式错乱、排版全无的糟糕体验？EPUB Translator 的智能翻译技术不仅完美保留原书的精美版式，更独创双语对照功能，让语言学习变得前所未有的直观高效。
+
+无论是阅读原著小说还是学习专业文献，现在你都能获得精准对齐的双语文本，所有插图、章节和特殊格式都完整保留。原句与译文并排呈现，助你轻松对比学习，就像拥有了一位随时在侧的翻译导师，让跨语言阅读真正成为愉悦的学习之旅。
+
+<!-- truncate -->
+
 <ResponsiveVideoEmbed
   src="//player.bilibili.com/player.html?isOutside=true&aid=114821034939492&bvid=BV1Y9G4z5Ewt&cid=30930898620&p=1"
   title="AI 翻译制作双语 EPUB 电子书视频"
   scrolling="no"
 />
-
-是否厌倦了电子书翻译后格式错乱、排版全无的糟糕体验？EPUB Translator 的智能翻译技术不仅完美保留原书的精美版式，更独创双语对照功能，让语言学习变得前所未有的直观高效。
-
-无论是阅读原著小说还是学习专业文献，现在你都能获得精准对齐的双语文本，所有插图、章节和特殊格式都完整保留。原句与译文并排呈现，助你轻松对比学习，就像拥有了一位随时在侧的翻译导师，让跨语言阅读真正成为愉悦的学习之旅。
 
 <figure>
   <Image

--- a/i18n/zh-CN/docusaurus-plugin-content-blog/2025-07-14-Convert-scanned-PDF-books-to-EPUB/index.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-blog/2025-07-14-Convert-scanned-PDF-books-to-EPUB/index.mdx
@@ -9,12 +9,6 @@ import Image from "@theme/ThemedImage";
 import useBaseUrl from "@docusaurus/useBaseUrl";
 import ResponsiveVideoEmbed from "@site/src/components/mdx/ResponsiveVideoEmbed";
 
-<ResponsiveVideoEmbed
-  src="https://www.youtube.com/embed/1yYBCVry77I?si=EfPneR7SHgrZ4J7Y"
-  title="PDF Craft: 将扫描版 PDF 书籍转换为 EPUB 视频"
-  referrerPolicy="strict-origin-when-cross-origin"
-/>
-
 你是否也收藏了大量的扫描版 PDF 文档？那些学术论文、电子书或者工作资料，虽然内容珍贵，但阅读体验却很糟糕——僵硬的版式、无法调整的字体大小，在手机上阅读时总是需要不断缩放。
 
 现在，这些 PDF 可以通过 pdf-craft 轻松转换成舒适的 EPUB 格式。就像把一堆纸质文档整理成便携的电子书，你终于可以在自己喜欢的 EPUB 阅读器上，以最适合自己的方式浏览这些内容：调整字号、切换夜间模式，甚至可以让 AI 朗读。
@@ -22,6 +16,14 @@ import ResponsiveVideoEmbed from "@site/src/components/mdx/ResponsiveVideoEmbed"
 [pdf-craft](https://github.com/oomol-lab/pdf-craft) 是一个专门用于处理扫描版书籍 PDF 的开源库。它可以精准识别 PDF 文件中的文本内容、页眉页脚、参考注释等。能够保持跨页内容的连贯性，还原正确的阅读顺序。此外，它还会使用 LLM 来构建完整的 EPUB 目录结构。
 
 在 oomol 中使用 pdf-craft 非常简单。首先，创建一个空白项目。然后在 [oomol store](https://hub.oomol.com/package/pdf-craft) 的搜索框中输入"pdf-craft"即可找到它。
+
+<!-- truncate -->
+
+<ResponsiveVideoEmbed
+  src="https://www.youtube.com/embed/1yYBCVry77I?si=EfPneR7SHgrZ4J7Y"
+  title="PDF Craft: 将扫描版 PDF 书籍转换为 EPUB 视频"
+  referrerPolicy="strict-origin-when-cross-origin"
+/>
 
 
 <figure>

--- a/i18n/zh-CN/docusaurus-plugin-content-blog/2025-07-14-write-code-INSIDE-your-workflow/index.mdx
+++ b/i18n/zh-CN/docusaurus-plugin-content-blog/2025-07-14-write-code-INSIDE-your-workflow/index.mdx
@@ -19,6 +19,8 @@ import ResponsiveVideoEmbed from "@site/src/components/mdx/ResponsiveVideoEmbed"
 
 我在视频中完整演示了如何用代码插槽快速构建自定义图片处理流程。
 
+<!-- truncate -->
+
 <ResponsiveVideoEmbed
   src="//player.bilibili.com/player.html?isOutside=true&aid=114714885558292&bvid=BV1MmKwzDEY6&cid=30598892330&p=1"
   title="在工作流中畅写代码视频"

--- a/i18n/zh-CN/docusaurus-theme-classic/footer.json
+++ b/i18n/zh-CN/docusaurus-theme-classic/footer.json
@@ -29,7 +29,7 @@
   },
   "link.item.label.Documentation": {
     "message": "文档",
-    "description": "The label of footer link with label=Documentation linking to /docs/introduction/overview"
+    "description": "The label of footer link with label=Documentation linking to /docs/overview"
   },
   "link.item.label.Updates": {
     "message": "更新日志",

--- a/src/components/SiteCta/styles.module.scss
+++ b/src/components/SiteCta/styles.module.scss
@@ -6,7 +6,7 @@
      `.inner` card never touches the viewport edge on narrow screens. */
   padding: clamp(5rem, 10vw, 8rem) clamp(16px, 4vw, 32px)
     clamp(3.5rem, 7vw, 5.5rem);
-  background: var(--oomol-bg-spotlight);
+  background: var(--ifm-footer-background-color);
   box-sizing: border-box;
 }
 
@@ -23,7 +23,7 @@
   padding-bottom: clamp(2.2rem, 5vw, 3.5rem);
   border: 1px solid var(--oomol-border-default);
   border-radius: 14px;
-  background: var(--oomol-bg-base);
+  background: var(--ifm-footer-background-color);
   text-align: center;
 }
 
@@ -119,15 +119,5 @@
   .ctaTitle {
     font-size: var(--oomol-display-card);
     line-height: 1.14;
-  }
-}
-
-[data-theme="dark"] {
-  .section {
-    background: var(--oomol-bg-container);
-  }
-
-  .inner {
-    background: var(--oomol-bg-elevated);
   }
 }

--- a/src/components/mdx/ResponsiveVideoEmbed.tsx
+++ b/src/components/mdx/ResponsiveVideoEmbed.tsx
@@ -48,6 +48,7 @@ export default function ResponsiveVideoEmbed({
         allow={allow}
         allowFullScreen={allowFullScreen}
         frameBorder={frameBorder}
+        loading={loading}
         style={{
           width: "100%",
           height: "100%",

--- a/src/components/mdx/ResponsiveVideoEmbed.tsx
+++ b/src/components/mdx/ResponsiveVideoEmbed.tsx
@@ -23,6 +23,7 @@ export default function ResponsiveVideoEmbed({
   allow = defaultAllow,
   allowFullScreen = true,
   frameBorder = "0",
+  loading = "lazy",
   ...properties
 }: ResponsiveVideoEmbedProps) {
   return (

--- a/src/theme/Navbar/index.tsx
+++ b/src/theme/Navbar/index.tsx
@@ -492,13 +492,17 @@ const NavbarComponent: React.FC<NavbarProps> = memo(() => {
             </BrowserOnly>
           </div>
         </div>
-        <div
-          aria-label="Navigation bar toggle"
+        <button
+          type="button"
+          aria-label={translate({
+            id: "theme.docs.sidebar.toggleSidebarButtonAriaLabel",
+            message: "Toggle navigation bar",
+            description:
+              "The ARIA label for hamburger menu button of mobile navigation",
+          })}
+          aria-expanded={mobileSidebar.shown}
           className="navbar__toggle"
-          role="button"
-          tabIndex={0}
           onClick={mobileSidebar.toggle}
-          onKeyDown={mobileSidebar.toggle}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -516,7 +520,7 @@ const NavbarComponent: React.FC<NavbarProps> = memo(() => {
               d="M4 7h22M4 15h22M4 23h22"
             />
           </svg>
-        </div>
+        </button>
       </div>
       <div
         role="presentation"


### PR DESCRIPTION
## What changed

This PR bundles three related cleanup/fix passes across the marketing site:

- aligned the shared CTA surface with the footer background token
- unified desktop and mobile navbar product links and improved mobile toggle behavior
- fixed blog media embeds so video players stay on post pages instead of leaking into blog list and tag pages

## Why

There were a few consistency regressions across shared site chrome and content surfaces:

- the shared CTA component was not tied directly to the footer background token
- desktop and mobile product navigation were using different targets for `oo-cli`
- the mobile navbar toggle was using a generic `div` with keydown toggling behavior
- blog list and tag pages were rendering full embedded video players from post bodies, which could lead to multiple active media contexts and noisy summaries/structured data

## User impact

- CTA sections now visually match the footer more closely
- product links resolve consistently across desktop and mobile navigation
- mobile navbar toggle behavior is more standard and accessible
- blog index/tag pages now show text previews instead of embedded players, while post detail pages still keep the videos
- older image-led blog posts now expose clean descriptions for previews and structured data

## Root cause

The navbar had split logic between custom desktop product entries and config-driven mobile items. Separately, several blog posts had no truncation marker or explicit description, so Docusaurus used component-led content as list previews and metadata.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run build`

## Notes

This PR is opened as a draft because it combines the recent navigation/footer cleanup with the blog media preview fixes and a follow-up lint fix for iframe loading.