### PR TITLE
[codex] Align homepage video width

### DIFF
--- a/src/components/HomepageFirstScreen/index.tsx
+++ b/src/components/HomepageFirstScreen/index.tsx
@@ -73,10 +73,10 @@ export default function HomepageFirstScreen() {
 
         <HomepageHeroBeam />
         */}
+      </div>
 
-        <div className={styles.workflowArchive}>
-          <HomepageFirstScreenVideoHero />
-        </div>
+      <div className={styles.workflowArchive}>
+        <HomepageFirstScreenVideoHero />
       </div>
     </section>
   );

--- a/src/components/HomepageFirstScreen/styles.module.scss
+++ b/src/components/HomepageFirstScreen/styles.module.scss
@@ -65,7 +65,9 @@
 }
 
 .workflowArchive {
+  width: min(1200px, calc(100% - 48px));
   margin-top: clamp(1.6rem, 3vw, 2.4rem);
+  margin-inline: auto;
 }
 
 .primaryCta,
@@ -84,8 +86,7 @@
 }
 
 .videoShowcaseInner {
-  width: min(1200px, calc(100% - 48px));
-  margin: 0 auto;
+  width: 100%;
 }
 
 /* ── English overrides ── */
@@ -179,11 +180,12 @@
   }
 
   .workflowArchive {
+    width: min(100%, calc(100% - 40px));
     margin-top: clamp(1.2rem, 5vw, 1.75rem);
   }
 
   .videoShowcaseInner {
-    width: min(100%, calc(100% - 32px));
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary

Align the homepage first-screen video with the content width used by the following `Why you need oo-cli` section.

## Root Cause

The hero video was nested inside the first-screen text container and then applied an additional `calc(100% - 48px)` width constraint inside that already padded container. This made the video narrower than the following content section and could create visually uneven side whitespace.

## Changes

- Move the workflow video block out of the hero text container so it is no longer affected by that container's internal padding.
- Apply the same 1200px centered content width directly to the video wrapper.
- Keep the inner video showcase at `width: 100%` to avoid double-subtracting horizontal space.
- Match the mobile width rule to the following content section.

## Validation

- `npm run lint`
- `npm run typecheck`
- `git diff --check`
- Browser DOM measurements with `agent-browser` confirmed the video and following content section share identical left/right edges on desktop and mobile viewports.
