### PR TITLE
[codex] Refine product page messaging

### DIFF
--- a/src/components/CloudPageFirstScreen/index.tsx
+++ b/src/components/CloudPageFirstScreen/index.tsx
@@ -10,7 +10,6 @@ import { HeroVideoDialog } from "@site/src/components/ui/hero-video-dialog";
 import React from "react";
 
 const zhCopy = {
-  eyebrow: "OOMOL Cloud",
   slogan: `把工具的交付、托管运行
 和访问控制交给 Cloud`,
   overview: `Studio 负责把工具做出来并验证；Cloud 负责把它交付出去，承接托管运行、配置和权限，并继续主要沿 oo-cli 给 Agent 使用。`,
@@ -21,7 +20,6 @@ const zhCopy = {
 };
 
 const enCopy = {
-  eyebrow: "OOMOL Cloud",
   slogan: `Put delivery, hosted runtime,
 and access control in Cloud`,
   overview: `Studio is where the tool gets built and validated. Cloud is where delivery happens, with hosted runtime, configuration, and access handled in one place, then used mainly through oo-cli by agents.`,
@@ -51,7 +49,6 @@ export default function CloudPageFirstScreen() {
     <section className={styles.section}>
       <div className={styles.container}>
         <div className={styles.titleGroup}>
-          <div className={styles.eyebrow}>{copy.eyebrow}</div>
           <h1 className={styles.slogan}>{copy.slogan}</h1>
           <p className={styles.overview}>{copy.overview}</p>
           <div className={styles.highlights}>

--- a/src/components/CloudPageFirstScreen/styles.module.scss
+++ b/src/components/CloudPageFirstScreen/styles.module.scss
@@ -27,32 +27,6 @@
   text-align: center;
 }
 
-/* Mono eyebrow with dot marker — matches global landing rule */
-.eyebrow {
-  display: inline-flex;
-  align-items: center;
-  width: fit-content;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  font-family: var(--oomol-font-mono);
-  font-size: var(--oomol-body-mono);
-  font-weight: 500;
-  letter-spacing: var(--oomol-tracking-mono);
-  text-transform: none;
-  color: var(--oomol-primary);
-
-  &::before {
-    content: "";
-    display: inline-block;
-    width: 6px;
-    height: 6px;
-    margin-right: 0.55rem;
-    border-radius: 999px;
-    background: var(--oomol-primary);
-  }
-}
-
 .slogan {
   @include marketing-display-title(hero, 100%, center, 1.04);
   white-space: pre-line;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -3,7 +3,16 @@ type TrackingConsentState = {
   analytics: boolean;
 };
 
-type GtagFunction = Gtag.Gtag;
+type GtagConsentValue = "denied" | "granted";
+
+type GtagConsentParams = {
+  ad_personalization?: GtagConsentValue;
+  ad_storage?: GtagConsentValue;
+  ad_user_data?: GtagConsentValue;
+  analytics_storage?: GtagConsentValue;
+};
+
+type GtagFunction = (...args: unknown[]) => void;
 
 declare global {
   interface Window {
@@ -171,13 +180,15 @@ function initializeGtag() {
   }
 
   if (!window.__oomolGoogleTagConfigured) {
-    window.gtag("js", new Date());
-    window.gtag("consent", "default", {
+    const defaultConsentParams: GtagConsentParams = {
       ad_personalization: "denied",
       ad_storage: "denied",
       ad_user_data: "denied",
       analytics_storage: "denied",
-    } as unknown as Gtag.ConsentParams);
+    };
+
+    window.gtag("js", new Date());
+    window.gtag("consent", "default", defaultConsentParams);
     window.__oomolGoogleTagConfigured = {
       ads: false,
       analytics: false,
@@ -232,12 +243,14 @@ export function updateGoogleConsent(
     return false;
   }
 
-  window.gtag?.("consent", "update", {
+  const consentParams: GtagConsentParams = {
     ad_storage: consentState.advertising ? "granted" : "denied",
     ad_user_data: consentState.advertising ? "granted" : "denied",
     ad_personalization: consentState.advertising ? "granted" : "denied",
     analytics_storage: consentState.analytics ? "granted" : "denied",
-  } as unknown as Gtag.ConsentParams);
+  };
+
+  window.gtag?.("consent", "update", consentParams);
 
   return true;
 }

--- a/src/pages/app/index.tsx
+++ b/src/pages/app/index.tsx
@@ -71,15 +71,10 @@ const VIDEO_FILES = {
   },
 } as const;
 
-/** 与导出素材一致；若源文件改版请同步更新（用于 /app 尺寸标注）。 */
-const APP_MEDIA_PIXELS = {
-  video4k: { width: 3840, height: 2160 },
-  nativeWorkspacePng: { width: 2470, height: 1964 },
+/** 与导出素材一致；若源文件改版请同步更新图片固有尺寸。 */
+const APP_MEDIA_INTRINSIC_SIZE = {
+  nativeWorkspace: { width: 2470, height: 1964 },
 } as const;
-
-function formatMediaPixelDimensions(width: number, height: number): string {
-  return `${width} × ${height}`;
-}
 
 const APP_DESKTOP_DOWNLOAD_URLS = {
   macos: "https://app-downloads.oomol.com/oomol-ai/darwin/arm64",
@@ -125,9 +120,9 @@ const COPY = {
         "当你更喜欢图形界面时，可以在 Web、桌面和 iOS 中直接使用 OOMOL 的工具，适合连续对话、查看结果和继续处理任务。",
     },
     hero: {
-      titleLine1: "OOMOL AI，把工具使用体验",
-      titleLine2: "直接带进图形界面",
-      lead: "悟墨 AI 是给人直接打开来用的官方图形入口，更适合连续对话、查看结果和继续处理任务。",
+      titleLine1: "悟墨 AI，让 OOMOL 工具",
+      titleLine2: "在图形界面里直接可用",
+      lead: "面向日常使用的官方图形入口。你可以在 Web、桌面和 iOS 上发起任务、查看结果，并在同一个上下文里继续处理。",
       productScreenshotAlt: "悟墨 AI 中由 Agent 原生调用工具完成任务的界面",
     },
     actions: {
@@ -136,74 +131,73 @@ const COPY = {
       ios: "iOS",
     },
     models: {
-      title: "更适合日常打开来用",
+      title: "把任务留在一个工作区",
       description:
-        "在这里，搜索、执行、查看结果和继续处理都留在同一个工作区里。",
+        "从连接账号、调用工具，到查看输出、继续追问，都在同一处完成。",
       demo: {
-        eyebrow: "一个工作区",
-        title: "让任务在一个界面里继续往下走",
-        description: "从搜索工具到查看结果，再到继续处理，都不需要来回跳转。",
+        title: "任务不用在多个入口之间来回切换",
+        description: "搜索、执行、结果和后续处理都围绕同一个上下文展开。",
         imageAlt: "悟墨 AI 中原生工具能力与小程序工作台界面",
       },
       cards: {
         chat: {
           eyebrow: "连续处理",
-          title: "搜索、执行和结果都留在同一界面",
-          body: "账号连接、任务运行和现成工具的调用，会直接进入当前工作区，不再散落在额外步骤里。",
-          chips: ["一个工作区", "连续处理", "直接打开用"],
+          title: "从发起任务到查看结果，都在当前页面",
+          body: "账号连接、任务运行和工具调用会自然衔接到当前工作区，不需要在不同产品形态之间来回找入口。",
+          chips: ["一个工作区", "连续处理", "直接使用"],
         },
         image: {
-          eyebrow: "结果跟进",
-          title: "更适合看结果、继续追问、继续处理",
-          body: "当你拿到结果后，可以直接补充要求、继续追问或执行下一步，而不是先换回别的入口。",
-          chips: ["先看结果", "继续追问", "继续处理"],
+          eyebrow: "后续跟进",
+          title: "拿到结果后，可以继续追问或继续执行",
+          body: "图片、文档、表格和中间结果都留在页面里，适合边看边改、边确认边推进。",
+          chips: ["查看结果", "继续追问", "继续执行"],
         },
       },
     },
     problems: {
-      titleLine1: "什么时候",
-      titleLine2: "图形界面会更顺手",
+      titleLine1: "这些场景，",
+      titleLine2: "图形界面更合适",
       cards: [
         {
-          title: "你会经常开着它",
-          body: "相比一次性命令调用，图形界面更适合日常打开、随时回来继续。",
+          title: "需要反复查看和调整",
+          body: "当任务不是一次性结束，而是需要看结果、补充要求、继续修改时，图形界面更直观。",
         },
         {
-          title: "你需要看结果再决定下一步",
-          body: "图片、文档、表格或中间结果留在当前界面里，会更容易继续跟进。",
+          title: "希望结果和上下文留在一起",
+          body: "图片、文档、表格或中间结果保留在当前工作区里，后续处理会更容易接上。",
         },
         {
-          title: "你想少一点切换，多一点连续感",
-          body: "当搜索、执行和追问都留在一个工作区里，处理任务会更自然。",
+          title: "想减少入口和设备切换",
+          body: "Web、桌面和 iOS 使用一致的图形入口，日常打开、回来继续都更顺手。",
         },
       ] as ProblemCard[],
     },
     workflow: {
       steps: [
         {
-          title: "先说目标，再开始处理",
-          body: "你先描述任务，界面再接住后面的搜索与执行。",
-          detail: "更像日常打开来用的工作区，而不是一串命令。",
+          title: "描述任务后，直接开始",
+          body: "用自然语言说明目标，悟墨 AI 会在当前工作区里衔接搜索、工具调用和执行过程。",
+          detail: "适合不想切换终端或多套入口的日常任务。",
           alt: "悟墨 AI 中由 Agent 主动搜索和调用技能的界面",
         },
         {
-          title: "结果出来后，直接继续下一步",
-          body: "查看结果、补充要求、继续处理，都可以留在当前页面里完成。",
-          detail: "适合需要边看边改、边问边做的任务。",
+          title: "看到结果后，接着处理",
+          body: "结果、补充要求和下一步操作都保留在当前页面。",
+          detail: "适合边看边改、边确认边推进的任务。",
           alt: "悟墨 AI 中继续执行多步工具任务的界面",
         },
         {
-          title: "换设备时，当前工作还能继续",
-          body: "Web、桌面和 iOS 都可以继续使用，不必重新理解另一套界面。",
-          detail: "你打开哪个入口，取决于当下最顺手的设备。",
+          title: "换到其他设备，也能继续",
+          body: "Web、桌面和 iOS 使用同一套入口和上下文，不需要重新适应。",
+          detail: "在电脑前处理复杂任务，离开座位后继续查看进展。",
           alt: "悟墨 AI 中将结果与 OOMOL 工具体系继续连接的界面",
         },
       ],
     },
     outputs: {
-      title: "终端适合接入，图形界面适合持续使用",
+      title: "CLI 适合集成，悟墨 AI 适合日常使用",
       description:
-        "oo-cli 更适合给 Agent 和终端接入；悟墨 AI 更适合你直接打开来用，持续查看结果并继续处理。",
+        "oo-cli 适合把工具接入 Agent 和终端流程；悟墨 AI 适合你直接打开，用图形界面查看结果并继续处理。",
       imageAlt: "悟墨 AI 中使用同一套工具能力持续完成任务的界面",
     },
     pricing: {
@@ -253,24 +247,24 @@ const COPY = {
       },
     },
     downloads: {
-      title: "从你最顺手的入口打开",
+      title: "选择当前最方便的入口",
       items: {
         web: {
-          title: "Web",
+          title: "网页版",
           subtitle: "对话式图形入口",
-          description: "最快开始使用。",
+          description: "无需安装，打开浏览器即可开始。",
           action: "打开网页版",
         },
         desktop: {
-          title: "Desktop",
+          title: "桌面版",
           subtitle: "桌面应用",
-          description: "适合更稳定的工作区与更长时间的连续处理。",
+          description: "适合长时间保持工作区，并连续处理复杂任务。",
           action: "下载桌面版",
         },
         ios: {
           title: "iOS",
           subtitle: "移动应用",
-          description: "适合随时查看进展，并继续当前任务。",
+          description: "适合在移动设备上查看进展，并继续当前任务。",
           action: "打开 App Store",
         },
       },
@@ -301,7 +295,6 @@ const COPY = {
       description:
         "Search, execution, results, and follow-up work all stay in one workspace.",
       demo: {
-        eyebrow: "One workspace",
         title: "Keep the task moving in one workspace",
         description:
           "From searching for tools to reviewing results and continuing the work, you do not need to bounce between separate interfaces.",
@@ -628,15 +621,17 @@ export default function AppPage() {
   const workflowSteps: readonly WorkflowStep[] = [
     {
       ...copy.workflow.steps[0],
-      videoSrc: getLocalizedVideoSrc(VIDEO_FILES.startFast, isZh),
+      videoSrc: useBaseUrl(getLocalizedVideoSrc(VIDEO_FILES.startFast, isZh)),
     },
     {
       ...copy.workflow.steps[1],
-      videoSrc: getLocalizedVideoSrc(VIDEO_FILES.keepEditing, isZh),
+      videoSrc: useBaseUrl(getLocalizedVideoSrc(VIDEO_FILES.keepEditing, isZh)),
     },
     {
       ...copy.workflow.steps[2],
-      videoSrc: getLocalizedVideoSrc(VIDEO_FILES.trustSources, isZh),
+      videoSrc: useBaseUrl(
+        getLocalizedVideoSrc(VIDEO_FILES.trustSources, isZh)
+      ),
     },
   ];
 
@@ -781,12 +776,6 @@ export default function AppPage() {
                     label={copy.hero.productScreenshotAlt}
                   />
                 </div>
-                <figcaption className={styles.mediaDimension}>
-                  {formatMediaPixelDimensions(
-                    APP_MEDIA_PIXELS.video4k.width,
-                    APP_MEDIA_PIXELS.video4k.height
-                  )}
-                </figcaption>
               </figure>
             </div>
           </div>
@@ -829,9 +818,6 @@ export default function AppPage() {
         >
           <div className={styles.modelDemo}>
             <div className={styles.modelDemoCopy}>
-              <p className={styles.modelDemoEyebrow}>
-                {copy.models.demo.eyebrow}
-              </p>
               <h2 id="models-demo-heading" className={styles.modelDemoTitle}>
                 {copy.models.demo.title}
               </h2>
@@ -845,17 +831,11 @@ export default function AppPage() {
                 src={nativeWorkspacePng}
                 alt={copy.models.demo.imageAlt}
                 className={styles.modelDemoImage}
-                width={APP_MEDIA_PIXELS.nativeWorkspacePng.width}
-                height={APP_MEDIA_PIXELS.nativeWorkspacePng.height}
+                width={APP_MEDIA_INTRINSIC_SIZE.nativeWorkspace.width}
+                height={APP_MEDIA_INTRINSIC_SIZE.nativeWorkspace.height}
                 loading="lazy"
                 decoding="async"
               />
-              <figcaption className={styles.mediaDimension}>
-                {formatMediaPixelDimensions(
-                  APP_MEDIA_PIXELS.nativeWorkspacePng.width,
-                  APP_MEDIA_PIXELS.nativeWorkspacePng.height
-                )}
-              </figcaption>
             </figure>
           </div>
         </section>
@@ -898,12 +878,6 @@ export default function AppPage() {
                       src={step.videoSrc}
                       label={step.alt}
                     />
-                    <figcaption className={styles.mediaDimension}>
-                      {formatMediaPixelDimensions(
-                        APP_MEDIA_PIXELS.video4k.width,
-                        APP_MEDIA_PIXELS.video4k.height
-                      )}
-                    </figcaption>
                   </figure>
                 </div>
 
@@ -934,12 +908,6 @@ export default function AppPage() {
                   label={copy.outputs.imageAlt}
                 />
               </div>
-              <figcaption className={styles.mediaDimension}>
-                {formatMediaPixelDimensions(
-                  APP_MEDIA_PIXELS.video4k.width,
-                  APP_MEDIA_PIXELS.video4k.height
-                )}
-              </figcaption>
             </figure>
           </div>
         </section>

--- a/src/pages/app/styles.module.scss
+++ b/src/pages/app/styles.module.scss
@@ -7,6 +7,8 @@
   --app-showcase-media-max: var(--page-width);
   --app-radius: var(--oomol-radius-lg);
   --app-radius-pill: var(--oomol-radius-full);
+  --app-hero-pad-bottom: clamp(2.75rem, 5vw, 4.75rem);
+  --app-first-section-pad-top: clamp(3.25rem, 5.5vw, 5.25rem);
   --app-section-pad-top: clamp(5.75rem, 8.5vw, 8rem);
   --app-section-pad-bottom: clamp(5.75rem, 9vw, 8.5rem);
   --app-block-gap-after-grid: clamp(1.5rem, 3.5vw, 2.75rem);
@@ -66,6 +68,7 @@
   padding-inline: clamp(20px, 5vw, 24px);
   /* 与导航之间留出呼吸感，避免 slogan 顶得太死 */
   padding-top: clamp(3.5rem, 6vw + 1rem, 6rem);
+  padding-bottom: var(--app-hero-pad-bottom);
   background: var(--oomol-bg-base);
   border-bottom: 1px solid var(--oomol-divider);
 }
@@ -216,30 +219,12 @@ video.outputsShowcaseImage {
   background: var(--oomol-bg-elevated);
 }
 
-/*
- * 媒体尺寸标注：与营销站中性层级一致（小字号、tertiary、不加重），
- * 格式统一为「宽 × 高」像素，便于全站沿用同一套规范。
- */
 .mediaFigure {
   margin: 0;
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 0.375rem;
   width: 100%;
-}
-
-.mediaDimension {
-  margin: 0;
-  align-self: flex-end;
-  max-width: 100%;
-  font-size: var(--oomol-font-size-xs);
-  line-height: 1.35;
-  font-weight: 400;
-  font-variant-numeric: tabular-nums;
-  letter-spacing: var(--oomol-tracking-mono);
-  color: var(--oomol-text-tertiary);
-  text-align: right;
 }
 
 .modelDemoMediaFigure {
@@ -255,6 +240,10 @@ video.outputsShowcaseImage {
 .section {
   padding-top: var(--app-section-pad-top);
   scroll-margin-top: calc(var(--ifm-navbar-height) + 22px);
+}
+
+.hero + .section {
+  padding-top: var(--app-first-section-pad-top);
 }
 
 .sectionIntro {
@@ -281,6 +270,12 @@ video.outputsShowcaseImage {
 .downloadsIntro {
   justify-items: center;
   margin-inline: auto;
+  text-align: center;
+}
+
+.modelsIntro p,
+.outputsIntro p,
+.pricingIntro p {
   text-align: center;
 }
 
@@ -352,8 +347,7 @@ video.outputsShowcaseImage {
   animation-delay: 220ms;
 }
 
-.modelFeatureEyebrow,
-.modelDemoEyebrow {
+.modelFeatureEyebrow {
   margin: 0;
 }
 

--- a/src/pages/studio/index.tsx
+++ b/src/pages/studio/index.tsx
@@ -98,9 +98,6 @@ export default function StudioPage() {
   const principlesTitleLines = translate({
     message: "STUDIO.product.principles.title",
   }).split("\n");
-  const heroKicker = translate({
-    message: "STUDIO.product.hero.kicker",
-  });
   const storyKicker = translate({
     message: "STUDIO.product.story.kicker",
   });
@@ -121,7 +118,6 @@ export default function StudioPage() {
         <section className={styles.hero}>
           <div className={styles.sectionContainer}>
             <div className={styles.heroCopy}>
-              <div className={styles.eyebrow}>{heroKicker}</div>
               <h1 className={styles.heroTitle}>
                 {heroTitleLines.map((line, index) => (
                   <React.Fragment key={`${index}-${line}`}>


### PR DESCRIPTION
## Summary

- Refined the OOMOL AI app page Chinese messaging so the page reads more naturally for the website audience.
- Fixed localized app page media URLs by routing workflow videos through Docusaurus `useBaseUrl`, and removed user-facing media dimension labels.
- Adjusted first-section spacing, centered intro subtitles, and removed redundant eyebrow labels from App, Cloud, and Studio hero areas.
- Replaced the analytics `Gtag` namespace dependency with local gtag typing so editors and TypeScript can resolve the file cleanly.

## Validation

- `npm run lint`
- `npm run typecheck`

## Notes

This is opened as a draft PR for review, following the local publish workflow.