### PR TITLE
Fix footer controls hiding navbar

### DIFF
--- a/src/components/CookieConsent/CookieConsentProvider.tsx
+++ b/src/components/CookieConsent/CookieConsentProvider.tsx
@@ -382,7 +382,11 @@ const CookieConsentProviderInner: React.FC = () => {
         </div>
       ) : null}
 
-      <Dialog.Root onOpenChange={setPreferencesOpen} open={preferencesOpen}>
+      <Dialog.Root
+        modal={false}
+        onOpenChange={setPreferencesOpen}
+        open={preferencesOpen}
+      >
         <Dialog.Portal>
           <Dialog.Overlay
             className="fixed inset-0 bg-[var(--oomol-mask)] [-webkit-backdrop-filter:blur(4px)] backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -2,7 +2,12 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import { cn } from "@site/src/lib/utils";
 import * as React from "react";
 
-const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenu = ({
+  modal = false,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) => (
+  <DropdownMenuPrimitive.Root modal={modal} {...props} />
+);
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
 const DropdownMenuPortal = DropdownMenuPrimitive.Portal;


### PR DESCRIPTION
根因：页脚的主题切换、语言切换、cookie 设置都用了 Radix 的 modal 行为，打开时 Radix 会锁住 body，导致
  body 的 computed overflow 变成 hidden。
## Summary
- Keep shared dropdown menus non-modal so footer theme and language controls do not lock body scrolling.
- Make the cookie settings dialog non-modal to avoid breaking the sticky navbar when opened from the footer.

## Test Plan
- npm run typecheck
- npm run build
- agent-browser verified theme, language, and cookie footer controls keep the navbar at top=0